### PR TITLE
ci: remove path filters from push triggers to main

### DIFF
--- a/.github/workflows/crm-api.yml
+++ b/.github/workflows/crm-api.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
     - main
-
-    paths:
-    - src/Services/CRM/**
-    - .github/workflows/crm-api.yml
   
   pull_request:
     branches:

--- a/.github/workflows/crm-migrator.yml
+++ b/.github/workflows/crm-migrator.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
     - main
-
-    paths:
-    - src/Services/CRM/Persistence/**
-    - .github/workflows/crm-migrator.yml
   
   pull_request:
     branches:

--- a/.github/workflows/envoy.yml
+++ b/.github/workflows/envoy.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
     - main
-
-    paths:
-    - src/Services/ApiGateways/Envoy/**
-    - .github/workflows/envoy.yml
   
   pull_request:
     branches:

--- a/.github/workflows/scheduling-api.yml
+++ b/.github/workflows/scheduling-api.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
     - main
-
-    paths:
-    - src/Services/Scheduling/**
-    - .github/workflows/scheduling-api.yml
   
   pull_request:
     branches:

--- a/.github/workflows/scheduling-migrator.yml
+++ b/.github/workflows/scheduling-migrator.yml
@@ -8,10 +8,6 @@ on:
   push:
     branches:
     - main
-
-    paths:
-    - src/Services/Scheduling/Persistence/**
-    - .github/workflows/scheduling-migrator.yml
   
   pull_request:
     branches:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
     - main
-
-    paths:
-    - src/web/**
-    - .github/workflows/web.yml
   
   pull_request:
     branches:


### PR DESCRIPTION
All workflows now run on every push to main branch regardless of changed files. Path filters are retained for pull requests to maintain build efficiency during development.

Affected workflows:
- crm-api
- crm-migrator
- envoy
- scheduling-api
- scheduling-migrator
- web