### PR TITLE
refactor(web): replace react-hook-form-mui with custom form components

### DIFF
--- a/src/web/eslint.config.ts
+++ b/src/web/eslint.config.ts
@@ -3,12 +3,11 @@ import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
-import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import { globalIgnores } from "eslint/config";
 import react from "eslint-plugin-react";
 import i18next from "eslint-plugin-i18next";
 
-const config: FlatConfig.ConfigArray = tseslint.config([
+const config = tseslint.config([
   globalIgnores([
     "dist",
     "eslint.config.ts",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -39,7 +39,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "translations:extract": "i18next -c ./i18next-parser.config.ts",
-    "typecheck": "tsc",
+    "typecheck": "tsc -b",
     "reset": "orval --clean && eslint --fix ./src/api && prettier --write ."
   },
   "browserslist": {

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -26,7 +26,6 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
-    "react-hook-form-mui": "^7.6.2",
     "react-i18next": "^15.7.4",
     "react-router-dom": "7.13.0",
     "vite-tsconfig-paths": "^6.1.1"

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
-      react-hook-form-mui:
-        specifier: ^7.6.2
-        version: 7.6.2(d53ec2da06f6ac780afbc29cbb1284ae)
       react-i18next:
         specifier: ^15.7.4
         version: 15.7.4(i18next@25.8.17(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -3239,21 +3236,6 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
-
-  react-hook-form-mui@7.6.2:
-    resolution: {integrity: sha512-mRzQHHxh45CD/89vxpTAGLeMYos78EmREG5J8TX4J2UOBT3gMUCPElp3Xr2b+ky1jI30UsqPEkQK44vThVSlkQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@mui/icons-material': '>= 5.x <8'
-      '@mui/material': '>= 5.x <8'
-      '@mui/x-date-pickers': '>=7.17.0 <8'
-      react: '>=17 <20'
-      react-hook-form: '>=7.33.1'
-    peerDependenciesMeta:
-      '@mui/icons-material':
-        optional: true
-      '@mui/x-date-pickers':
-        optional: true
 
   react-hook-form@7.71.2:
     resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
@@ -7469,15 +7451,6 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
-
-  react-hook-form-mui@7.6.2(d53ec2da06f6ac780afbc29cbb1284ae):
-    dependencies:
-      '@mui/material': 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-hook-form: 7.71.2(react@19.2.4)
-    optionalDependencies:
-      '@mui/icons-material': 7.3.7(@mui/material@7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@mui/x-date-pickers': 8.5.3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@mui/material@7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mui/system@7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   react-hook-form@7.71.2(react@19.2.4):
     dependencies:

--- a/src/web/src/components/child/BasicInformationCard.tsx
+++ b/src/web/src/components/child/BasicInformationCard.tsx
@@ -4,10 +4,8 @@ import { Grid } from "@mui/material";
 import { calculateAge } from "@utils/calculateAge";
 import { formatDate } from "@utils/formatDate";
 import { Person as PersonIcon } from "@mui/icons-material";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
 import { EditableCard } from "../cards/EditableCard";
-import { FieldDisplay } from "../forms/FieldDisplay";
+import { FieldDisplay, Form, FormTextField, FormDatePicker } from "../forms";
 import { type UseFormReturn } from "react-hook-form";
 
 type BasicInformationCardProps = {
@@ -72,29 +70,27 @@ export const BasicInformationCard: React.FC<BasicInformationCardProps> = ({
 
   // Edit mode content (use correct field names for form)
   const editContent = formContext ? (
-    <FormContainer formContext={formContext}>
+    <Form formContext={formContext}>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TextFieldElement name="givenName" label={t("First Name")} fullWidth required />
+          <FormTextField name="givenName" label={t("First Name")} fullWidth required />
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TextFieldElement name="familyName" label={t("Last Name")} fullWidth required />
+          <FormTextField name="familyName" label={t("Last Name")} fullWidth required />
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <DatePickerElement
+          <FormDatePicker
             name="dateOfBirth"
             label={t("Date of Birth")}
-            inputProps={{ fullWidth: true }}
+            slotProps={{ textField: { fullWidth: true } }}
             transform={{
-              output: (value) => {
-                return value ? value.format("YYYY-MM-DD") : null;
-              },
+              output: (value) => (value ? value.format("YYYY-MM-DD") : null),
             }}
             required
           />
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TextFieldElement
+          <FormTextField
             name="cid"
             label={t("CID")}
             fullWidth
@@ -103,7 +99,7 @@ export const BasicInformationCard: React.FC<BasicInformationCardProps> = ({
           />
         </Grid>
       </Grid>
-    </FormContainer>
+    </Form>
   ) : null;
 
   return (

--- a/src/web/src/components/forms/Form.tsx
+++ b/src/web/src/components/forms/Form.tsx
@@ -1,0 +1,46 @@
+import { type ReactNode } from "react";
+import {
+  FormProvider,
+  type FieldValues,
+  type SubmitHandler,
+  type UseFormReturn,
+} from "react-hook-form";
+
+export type FormProps<T extends FieldValues> = {
+  formContext: UseFormReturn<T>;
+  onSubmit?: SubmitHandler<T>;
+  children?: ReactNode;
+  noValidate?: boolean;
+  className?: string;
+};
+
+/**
+ * Lightweight replacement for `react-hook-form-mui`'s `FormContainer`.
+ *
+ * - When `onSubmit` is provided, renders a `<form>` element with the submit
+ *   handler wired through `formContext.handleSubmit`.
+ * - When `onSubmit` is omitted, only provides the form context (useful for
+ *   nested editable cards that share a single submit handler at the parent).
+ */
+export const Form = <T extends FieldValues>({
+  formContext,
+  onSubmit,
+  children,
+  noValidate = true,
+  className,
+}: FormProps<T>) => {
+  if (!onSubmit) {
+    return <FormProvider {...formContext}>{children}</FormProvider>;
+  }
+  return (
+    <FormProvider {...formContext}>
+      <form
+        noValidate={noValidate}
+        className={className}
+        onSubmit={formContext.handleSubmit(onSubmit)}
+      >
+        {children}
+      </form>
+    </FormProvider>
+  );
+};

--- a/src/web/src/components/forms/FormDatePicker.tsx
+++ b/src/web/src/components/forms/FormDatePicker.tsx
@@ -10,13 +10,13 @@ import dayjs, { type Dayjs } from "dayjs";
 import { useTranslation } from "react-i18next";
 
 export type FormDatePickerProps<T extends FieldValues> = Omit<
-  DatePickerProps<Dayjs>,
+  DatePickerProps,
   "value" | "onChange" | "name" | "defaultValue"
 > & {
   name: Path<T>;
   required?: boolean;
   rules?: Omit<
-    RegisterOptions<T, Path<T>>,
+    RegisterOptions,
     "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
   >;
   helperText?: string;
@@ -63,7 +63,9 @@ export const FormDatePicker = <T extends FieldValues>({
       control={control}
       rules={mergedRules}
       render={({ field, fieldState }) => {
-        const value = transform?.input ? transform.input(field.value) : defaultInputTransform(field.value);
+        const value = transform?.input
+          ? transform.input(field.value)
+          : defaultInputTransform(field.value);
         const existingTextField = (slotProps?.textField ?? {}) as Record<string, unknown>;
         return (
           <DatePicker

--- a/src/web/src/components/forms/FormDatePicker.tsx
+++ b/src/web/src/components/forms/FormDatePicker.tsx
@@ -1,0 +1,94 @@
+import {
+  Controller,
+  useFormContext,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+} from "react-hook-form";
+import { DatePicker, type DatePickerProps } from "@mui/x-date-pickers/DatePicker";
+import dayjs, { type Dayjs } from "dayjs";
+import { useTranslation } from "react-i18next";
+
+export type FormDatePickerProps<T extends FieldValues> = Omit<
+  DatePickerProps<Dayjs>,
+  "value" | "onChange" | "name" | "defaultValue"
+> & {
+  name: Path<T>;
+  required?: boolean;
+  rules?: Omit<
+    RegisterOptions<T, Path<T>>,
+    "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
+  >;
+  helperText?: string;
+  /**
+   * Map between the form value (typically a string like "YYYY-MM-DD")
+   * and the picker value (a Dayjs instance).
+   */
+  transform?: {
+    input?: (value: unknown) => Dayjs | null;
+    output?: (value: Dayjs | null) => unknown;
+  };
+};
+
+const defaultInputTransform = (value: unknown): Dayjs | null => {
+  if (value === null || value === undefined || value === "") return null;
+  if (dayjs.isDayjs(value)) return value;
+  return dayjs(value as string);
+};
+
+/**
+ * MUI `DatePicker` bound to react-hook-form via `Controller`.
+ * Replaces `DatePickerElement` from react-hook-form-mui.
+ */
+export const FormDatePicker = <T extends FieldValues>({
+  name,
+  required,
+  rules,
+  helperText,
+  transform,
+  slotProps,
+  ...rest
+}: FormDatePickerProps<T>) => {
+  const { control } = useFormContext<T>();
+  const { t } = useTranslation();
+
+  const mergedRules: RegisterOptions<T, Path<T>> = { ...rules } as RegisterOptions<T, Path<T>>;
+  if (required && !mergedRules.required) {
+    mergedRules.required = t("This field is required", { ns: "common" });
+  }
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={mergedRules}
+      render={({ field, fieldState }) => {
+        const value = transform?.input ? transform.input(field.value) : defaultInputTransform(field.value);
+        const existingTextField = (slotProps?.textField ?? {}) as Record<string, unknown>;
+        return (
+          <DatePicker
+            {...rest}
+            value={value}
+            inputRef={field.ref}
+            onChange={(next) => {
+              field.onChange(transform?.output ? transform.output(next) : next);
+            }}
+            slotProps={{
+              ...slotProps,
+              textField: {
+                ...existingTextField,
+                error: !!fieldState.error,
+                helperText:
+                  fieldState.error?.message ??
+                  helperText ??
+                  (existingTextField.helperText as string | undefined),
+                required,
+                onBlur: field.onBlur,
+              },
+            }}
+          />
+        );
+      }}
+    />
+  );
+};

--- a/src/web/src/components/forms/FormSelect.tsx
+++ b/src/web/src/components/forms/FormSelect.tsx
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  useFormContext,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+} from "react-hook-form";
+import TextField, { type TextFieldProps } from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import { useTranslation } from "react-i18next";
+
+export type FormSelectOption = {
+  id: string | number;
+  label: string;
+  disabled?: boolean;
+};
+
+export type FormSelectProps<T extends FieldValues> = Omit<
+  TextFieldProps,
+  "name" | "select" | "children" | "defaultValue" | "error"
+> & {
+  name: Path<T>;
+  options: FormSelectOption[];
+  rules?: Omit<
+    RegisterOptions<T, Path<T>>,
+    "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
+  >;
+};
+
+/**
+ * MUI `TextField` (with `select`) bound to react-hook-form via `Controller`.
+ * Replaces `SelectElement` from react-hook-form-mui.
+ */
+export const FormSelect = <T extends FieldValues>({
+  name,
+  options,
+  required,
+  rules,
+  helperText,
+  ...rest
+}: FormSelectProps<T>) => {
+  const { control } = useFormContext<T>();
+  const { t } = useTranslation();
+
+  const mergedRules: RegisterOptions<T, Path<T>> = { ...rules } as RegisterOptions<T, Path<T>>;
+  if (required && !mergedRules.required) {
+    mergedRules.required = t("This field is required", { ns: "common" });
+  }
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={mergedRules}
+      render={({ field, fieldState }) => (
+        <TextField
+          {...rest}
+          {...field}
+          value={field.value ?? ""}
+          inputRef={field.ref}
+          select
+          required={required}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message ?? helperText}
+        >
+          {options.map((opt) => (
+            <MenuItem key={opt.id} value={opt.id} disabled={opt.disabled}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      )}
+    />
+  );
+};

--- a/src/web/src/components/forms/FormSelect.tsx
+++ b/src/web/src/components/forms/FormSelect.tsx
@@ -22,7 +22,7 @@ export type FormSelectProps<T extends FieldValues> = Omit<
   name: Path<T>;
   options: FormSelectOption[];
   rules?: Omit<
-    RegisterOptions<T, Path<T>>,
+    RegisterOptions,
     "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
   >;
 };

--- a/src/web/src/components/forms/FormTextField.tsx
+++ b/src/web/src/components/forms/FormTextField.tsx
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  useFormContext,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+} from "react-hook-form";
+import TextField, { type TextFieldProps } from "@mui/material/TextField";
+import { useTranslation } from "react-i18next";
+
+export type FormTextFieldProps<T extends FieldValues> = Omit<
+  TextFieldProps,
+  "name" | "defaultValue" | "error"
+> & {
+  name: Path<T>;
+  rules?: Omit<
+    RegisterOptions<T, Path<T>>,
+    "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
+  >;
+};
+
+/**
+ * MUI `TextField` bound to react-hook-form via `Controller`.
+ * Replaces `TextFieldElement` from react-hook-form-mui.
+ */
+export const FormTextField = <T extends FieldValues>({
+  name,
+  rules,
+  required,
+  helperText,
+  ...rest
+}: FormTextFieldProps<T>) => {
+  const { control } = useFormContext<T>();
+  const { t } = useTranslation();
+
+  const mergedRules: RegisterOptions<T, Path<T>> = { ...rules } as RegisterOptions<T, Path<T>>;
+  if (required && !mergedRules.required) {
+    mergedRules.required = t("This field is required", { ns: "common" });
+  }
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={mergedRules}
+      render={({ field, fieldState }) => (
+        <TextField
+          {...rest}
+          {...field}
+          value={field.value ?? ""}
+          inputRef={field.ref}
+          required={required}
+          error={!!fieldState.error}
+          helperText={fieldState.error?.message ?? helperText}
+        />
+      )}
+    />
+  );
+};

--- a/src/web/src/components/forms/FormTextField.tsx
+++ b/src/web/src/components/forms/FormTextField.tsx
@@ -14,7 +14,7 @@ export type FormTextFieldProps<T extends FieldValues> = Omit<
 > & {
   name: Path<T>;
   rules?: Omit<
-    RegisterOptions<T, Path<T>>,
+    RegisterOptions,
     "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
   >;
 };

--- a/src/web/src/components/forms/FormTimeField.tsx
+++ b/src/web/src/components/forms/FormTimeField.tsx
@@ -6,17 +6,17 @@ import {
   type RegisterOptions,
 } from "react-hook-form";
 import { TimeField, type TimeFieldProps } from "@mui/x-date-pickers/TimeField";
-import dayjs, { type Dayjs } from "dayjs";
+import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 
 export type FormTimeFieldProps<T extends FieldValues> = Omit<
-  TimeFieldProps<Dayjs>,
+  TimeFieldProps,
   "value" | "onChange" | "name" | "defaultValue"
 > & {
   name: Path<T>;
   required?: boolean;
   rules?: Omit<
-    RegisterOptions<T, Path<T>>,
+    RegisterOptions,
     "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
   >;
   /** Format used for the displayed input. Default: "HH:mm". */

--- a/src/web/src/components/forms/FormTimeField.tsx
+++ b/src/web/src/components/forms/FormTimeField.tsx
@@ -1,0 +1,83 @@
+import {
+  Controller,
+  useFormContext,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+} from "react-hook-form";
+import { TimeField, type TimeFieldProps } from "@mui/x-date-pickers/TimeField";
+import dayjs, { type Dayjs } from "dayjs";
+import { useTranslation } from "react-i18next";
+
+export type FormTimeFieldProps<T extends FieldValues> = Omit<
+  TimeFieldProps<Dayjs>,
+  "value" | "onChange" | "name" | "defaultValue"
+> & {
+  name: Path<T>;
+  required?: boolean;
+  rules?: Omit<
+    RegisterOptions<T, Path<T>>,
+    "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
+  >;
+  /** Format used for the displayed input. Default: "HH:mm". */
+  displayFormat?: string;
+  /** Format used to store the value in the form state. Default: "HH:mm:ss". */
+  storeFormat?: string;
+};
+
+/**
+ * MUI `TimeField` bound to react-hook-form via `Controller`.
+ * Stores the value as a string (default: "HH:mm:ss").
+ */
+export const FormTimeField = <T extends FieldValues>({
+  name,
+  required,
+  rules,
+  displayFormat = "HH:mm",
+  storeFormat = "HH:mm:ss",
+  slotProps,
+  ...rest
+}: FormTimeFieldProps<T>) => {
+  const { control } = useFormContext<T>();
+  const { t } = useTranslation();
+
+  const mergedRules: RegisterOptions<T, Path<T>> = { ...rules } as RegisterOptions<T, Path<T>>;
+  if (required && !mergedRules.required) {
+    mergedRules.required = t("This field is required", { ns: "common" });
+  }
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={mergedRules}
+      render={({ field, fieldState }) => {
+        const value = field.value ? dayjs(field.value as string, storeFormat) : null;
+        const existingTextField = (slotProps?.textField ?? {}) as Record<string, unknown>;
+        return (
+          <TimeField
+            {...rest}
+            value={value}
+            inputRef={field.ref}
+            format={rest.format ?? displayFormat}
+            onChange={(next) => {
+              field.onChange(next?.format(storeFormat) ?? null);
+            }}
+            slotProps={{
+              ...slotProps,
+              textField: {
+                ...existingTextField,
+                error: !!fieldState.error,
+                helperText:
+                  fieldState.error?.message ??
+                  (existingTextField.helperText as string | undefined),
+                required,
+                onBlur: field.onBlur,
+              },
+            }}
+          />
+        );
+      }}
+    />
+  );
+};

--- a/src/web/src/components/forms/index.ts
+++ b/src/web/src/components/forms/index.ts
@@ -1,0 +1,6 @@
+export { Form, type FormProps } from "./Form";
+export { FormTextField, type FormTextFieldProps } from "./FormTextField";
+export { FormDatePicker, type FormDatePickerProps } from "./FormDatePicker";
+export { FormSelect, type FormSelectProps, type FormSelectOption } from "./FormSelect";
+export { FormTimeField, type FormTimeFieldProps } from "./FormTimeField";
+export { FieldDisplay } from "./FieldDisplay";

--- a/src/web/src/components/guardian/GuardianBasicInformationCard.tsx
+++ b/src/web/src/components/guardian/GuardianBasicInformationCard.tsx
@@ -4,10 +4,8 @@ import { Grid } from "@mui/material";
 import { calculateAge } from "../../utils/calculateAge";
 import { formatDate } from "../../utils/formatDate";
 import { Person as PersonIcon } from "@mui/icons-material";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
 import { EditableCard } from "../cards/EditableCard";
-import { FieldDisplay } from "../forms/FieldDisplay";
+import { FieldDisplay, Form, FormTextField, FormDatePicker } from "../forms";
 import { type UseFormReturn } from "react-hook-form";
 
 type GuardianBasicInformationCardProps = {
@@ -62,28 +60,26 @@ export const GuardianBasicInformationCard: React.FC<GuardianBasicInformationCard
 
   // Edit mode content
   const editContent = formContext ? (
-    <FormContainer formContext={formContext}>
+    <Form formContext={formContext}>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TextFieldElement name="givenName" label={t("Given Name")} fullWidth required />
+          <FormTextField name="givenName" label={t("Given Name")} fullWidth required />
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TextFieldElement name="familyName" label={t("Family Name")} fullWidth required />
+          <FormTextField name="familyName" label={t("Family Name")} fullWidth required />
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <DatePickerElement
+          <FormDatePicker
             name="dateOfBirth"
             label={t("Date of Birth")}
-            inputProps={{ fullWidth: true }}
+            slotProps={{ textField: { fullWidth: true } }}
             transform={{
-              output: (value) => {
-                return value ? value.format("YYYY-MM-DD") : null;
-              },
+              output: (value) => (value ? value.format("YYYY-MM-DD") : null),
             }}
           />
         </Grid>
       </Grid>
-    </FormContainer>
+    </Form>
   ) : null;
 
   return (

--- a/src/web/src/components/guardian/GuardianContactInformationCard.tsx
+++ b/src/web/src/components/guardian/GuardianContactInformationCard.tsx
@@ -8,9 +8,8 @@ import {
   Add as AddIcon,
   Delete as DeleteIcon,
 } from "@mui/icons-material";
-import { FormContainer, TextFieldElement, SelectElement } from "react-hook-form-mui";
+import { FieldDisplay, Form, FormTextField, FormSelect } from "../forms";
 import { EditableCard } from "../cards/EditableCard";
-import { FieldDisplay } from "../forms/FieldDisplay";
 import { type UseFormReturn, useFieldArray } from "react-hook-form";
 type PhoneNumber = {
   id?: string;
@@ -99,11 +98,11 @@ export const GuardianContactInformationCard: React.FC<GuardianContactInformation
   );
   // Edit mode content
   const editContent = formContext ? (
-    <FormContainer formContext={formContext}>
+    <Form formContext={formContext}>
       <Grid container spacing={3}>
         {/* Email */}
         <Grid size={{ xs: 12 }}>
-          <TextFieldElement
+          <FormTextField
             name="email"
             label={t("Email")}
             type="email"
@@ -163,7 +162,7 @@ export const GuardianContactInformationCard: React.FC<GuardianContactInformation
                   <Grid container spacing={2}>
                     {/* Type Selector */}
                     <Grid size={{ xs: 12, sm: 4 }}>
-                      <SelectElement
+                      <FormSelect
                         name={`phoneNumbers.${index}.type`}
                         label={t("Type")}
                         options={[
@@ -180,7 +179,7 @@ export const GuardianContactInformationCard: React.FC<GuardianContactInformation
                     {/* Phone Number */}
                     <Grid size={{ xs: 12, sm: 8 }}>
                       <Box sx={{ display: "flex", gap: 1, alignItems: "start" }}>
-                        <TextFieldElement
+                        <FormTextField
                           name={`phoneNumbers.${index}.number`}
                           label={t("Phone Number")}
                           placeholder="+31612345678"
@@ -238,7 +237,7 @@ export const GuardianContactInformationCard: React.FC<GuardianContactInformation
           )}
         </Grid>
       </Grid>
-    </FormContainer>
+    </Form>
   ) : null;
 
   return (

--- a/src/web/src/features/absence/AddAbsenceDialog.tsx
+++ b/src/web/src/features/absence/AddAbsenceDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { Form, FormTextField, FormDatePicker } from "@components/forms";
 import Button from "@mui/material/Button";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
@@ -13,7 +13,6 @@ import { useSnackbar } from "notistack";
 import dayjs from "dayjs";
 import { useForm, useWatch } from "react-hook-form";
 import { useAddAbsence } from "@api/scheduling/endpoints/absences/absences";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
 import { useQueryClient } from "@tanstack/react-query";
 
 type AddAbsenceDialogProps = {
@@ -107,20 +106,13 @@ export const AddAbsenceDialog = NiceModal.create<AddAbsenceDialogProps>(({ child
         <DialogContentText sx={{ mb: 2, color: "text.secondary", fontSize: "0.875rem" }}>
           {t("To add an absence, please enter the details below.")}
         </DialogContentText>
-        <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
-          <DatePickerElement
+        <Form formContext={formContext} onSubmit={onSubmit}>
+          <FormDatePicker
             label={t("Start Date")}
             name="startDate"
-            slotProps={{
-              textField: {
-                size: "small",
-                fullWidth: true,
-              },
-            }}
+            slotProps={{ textField: { size: "small", fullWidth: true } }}
             transform={{
-              output: (value) => {
-                return value ? value.format("YYYY-MM-DD") : null;
-              },
+              output: (value) => (value ? value.format("YYYY-MM-DD") : null),
             }}
           />
           <FormControlLabel
@@ -136,24 +128,17 @@ export const AddAbsenceDialog = NiceModal.create<AddAbsenceDialogProps>(({ child
             sx={{ mt: 1, mb: 1 }}
           />
           {multiDay && (
-            <DatePickerElement
+            <FormDatePicker
               label={t("Start Date")}
               name="endDate"
-              slotProps={{
-                textField: {
-                  size: "small",
-                  fullWidth: true,
-                },
-              }}
+              slotProps={{ textField: { size: "small", fullWidth: true } }}
               transform={{
-                output: (value) => {
-                  return value ? value.format("YYYY-MM-DD") : null;
-                },
+                output: (value) => (value ? value.format("YYYY-MM-DD") : null),
               }}
             />
           )}
-          <TextFieldElement name="reason" label={t("Reason")} fullWidth margin="normal" />
-        </FormContainer>
+          <FormTextField name="reason" label={t("Reason")} fullWidth margin="normal" />
+        </Form>
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleOnCancelClick}>

--- a/src/web/src/features/closurePeriods/AddClosurePeriodDialog.tsx
+++ b/src/web/src/features/closurePeriods/AddClosurePeriodDialog.tsx
@@ -14,8 +14,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import type { UnprocessableEntityResponse } from "@api/scheduling/models/unprocessableEntityResponse";
 import type { AddClosurePeriodCommand } from "@api/scheduling/models/addClosurePeriodCommand";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { Form, FormTextField, FormDatePicker } from "@components/forms";
 
 export const AddClosurePeriodDialog = NiceModal.create(() => {
   const modal = useModal();
@@ -72,39 +71,25 @@ export const AddClosurePeriodDialog = NiceModal.create(() => {
       <DialogTitle>{t("Add Closure Period")}</DialogTitle>
 
       <DialogContent>
-        <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
-          <TextFieldElement name="reason" label={t("Reason")} fullWidth margin="normal" />
-          <DatePickerElement
+        <Form formContext={formContext} onSubmit={onSubmit}>
+          <FormTextField name="reason" label={t("Reason")} fullWidth margin="normal" />
+          <FormDatePicker
             label={t("Start Date")}
             name="startDate"
-            slotProps={{
-              textField: {
-                size: "small",
-                fullWidth: true,
-              },
-            }}
+            slotProps={{ textField: { size: "small", fullWidth: true } }}
             transform={{
-              output: (value) => {
-                return value ? value.format("YYYY-MM-DD") : null;
-              },
+              output: (value) => (value ? value.format("YYYY-MM-DD") : null),
             }}
           />
-          <DatePickerElement
+          <FormDatePicker
             label={t("End Date")}
             name="endDate"
-            slotProps={{
-              textField: {
-                size: "small",
-                fullWidth: true,
-              },
-            }}
+            slotProps={{ textField: { size: "small", fullWidth: true } }}
             transform={{
-              output: (value) => {
-                return value ? value.format("YYYY-MM-DD") : null;
-              },
+              output: (value) => (value ? value.format("YYYY-MM-DD") : null),
             }}
           />
-        </FormContainer>
+        </Form>
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleOnCancelClick}>

--- a/src/web/src/features/groups/AddGroupDialog.tsx
+++ b/src/web/src/features/groups/AddGroupDialog.tsx
@@ -1,6 +1,6 @@
 import { type AddGroupCommand } from "@api/scheduling/models/addGroupCommand";
 import { type SubmitHandler, useForm } from "react-hook-form";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { Form, FormTextField } from "@components/forms";
 import Button from "@mui/material/Button";
 import { getListGroupsQueryKey, useAddGroup } from "@api/scheduling/endpoints/groups/groups";
 import DialogContent from "@mui/material/DialogContent";
@@ -64,8 +64,8 @@ export const AddGroupDialog = NiceModal.create(() => {
         <DialogContentText>
           {t("To add a group, please enter the group name here.")}
         </DialogContentText>
-        <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
-          <TextFieldElement
+        <Form formContext={formContext} onSubmit={onSubmit}>
+          <FormTextField
             autoFocus
             name="name"
             label={t("Name")}
@@ -74,7 +74,7 @@ export const AddGroupDialog = NiceModal.create(() => {
             autoComplete="off"
             fullWidth
           />
-        </FormContainer>
+        </Form>
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleOnCancelClick}>

--- a/src/web/src/features/guardians/GuardianForm.tsx
+++ b/src/web/src/features/guardians/GuardianForm.tsx
@@ -3,26 +3,20 @@ import { useTranslation } from "react-i18next";
 import {
   Box,
   Grid,
-  TextField,
   Button,
   Card,
   CardContent,
   Typography,
   Alert,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
   IconButton,
   Stack,
   Divider,
   Paper,
 } from "@mui/material";
 import { Add, Remove } from "@mui/icons-material";
-import { useForm, useFieldArray, Controller } from "react-hook-form";
+import { useForm, useFieldArray } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { Form, FormDatePicker, FormSelect, FormTextField } from "@components/forms";
 
 type PhoneNumber = {
   id?: string;
@@ -70,8 +64,6 @@ export const GuardianForm = ({
 
   const {
     control,
-    handleSubmit,
-    formState: { errors },
     reset,
   } = formContext;
 
@@ -112,7 +104,7 @@ export const GuardianForm = ({
   const removePhoneNumber = (index: number) => removePhone(index);
 
   return (
-    <FormContainer formContext={formContext} handleSubmit={handleSubmit(handleFormSubmit)}>
+    <Form formContext={formContext} onSubmit={handleFormSubmit}>
       <Typography variant="h4" gutterBottom>
         {t(title)}
       </Typography>
@@ -131,23 +123,19 @@ export const GuardianForm = ({
           </Typography>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6 }}>
-              <TextFieldElement name="givenName" label={t("Given name")} required fullWidth />
+              <FormTextField name="givenName" label={t("Given name")} required fullWidth />
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
-              <TextFieldElement name="familyName" label={t("Family name")} required fullWidth />
+              <FormTextField name="familyName" label={t("Family name")} required fullWidth />
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
-              <DatePickerElement
+              <FormDatePicker
                 label={t("Date of birth")}
                 name="dateOfBirth"
                 transform={{
-                  output: (value) => {
-                    return value ? value.format("YYYY-MM-DD") : null;
-                  },
+                  output: (value) => (value ? value.format("YYYY-MM-DD") : null),
                 }}
-                inputProps={{
-                  fullWidth: true,
-                }}
+                slotProps={{ textField: { fullWidth: true } }}
               />
             </Grid>
           </Grid>
@@ -162,7 +150,7 @@ export const GuardianForm = ({
           </Typography>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12 }}>
-              <TextFieldElement
+              <FormTextField
                 name="email"
                 label={t("Email")}
                 fullWidth
@@ -203,42 +191,32 @@ export const GuardianForm = ({
                   >
                     <Grid container spacing={2}>
                       <Grid size={{ xs: 12, sm: 4 }}>
-                        <Controller
+                        <FormSelect
                           name={`phoneNumbers.${index}.type`}
-                          control={control}
-                          render={({ field }) => (
-                            <FormControl fullWidth size="small">
-                              <InputLabel>{t("Type")}</InputLabel>
-                              <Select {...field} label={t("Type")}>
-                                <MenuItem value="Mobile">{t("Mobile")}</MenuItem>
-                                <MenuItem value="Home">{t("Home")}</MenuItem>
-                                <MenuItem value="Work">{t("Work")}</MenuItem>
-                                <MenuItem value="Other">{t("Other")}</MenuItem>
-                              </Select>
-                            </FormControl>
-                          )}
+                          label={t("Type")}
+                          options={[
+                            { id: "Mobile", label: t("Mobile") },
+                            { id: "Home", label: t("Home") },
+                            { id: "Work", label: t("Work") },
+                            { id: "Other", label: t("Other") },
+                          ]}
+                          fullWidth
+                          size="small"
                         />
                       </Grid>
                       <Grid size={{ xs: 12, sm: 8 }}>
-                        <Controller
+                        <FormTextField
                           name={`phoneNumbers.${index}.number`}
-                          control={control}
                           rules={{
                             validate: (val) =>
                               !val ||
                               /^\+?[1-9]\d{7,18}$/.test(val) ||
                               t("Must be E.164 format (e.g. +31612345678)"),
                           }}
-                          render={({ field }) => (
-                            <TextField
-                              {...field}
-                              fullWidth
-                              label={t("Phone Number")}
-                              error={!!errors.phoneNumbers?.[index]?.number}
-                              placeholder={t("+31612345678")}
-                              size="small"
-                            />
-                          )}
+                          fullWidth
+                          label={t("Phone Number")}
+                          placeholder={t("+31612345678")}
+                          size="small"
                         />
                       </Grid>
                     </Grid>
@@ -284,6 +262,6 @@ export const GuardianForm = ({
           {isLoading ? t("Saving...") : guardianId ? t("Update Guardian") : t("Create Guardian")}
         </Button>
       </Box>
-    </FormContainer>
+    </Form>
   );
 };

--- a/src/web/src/features/schedules/AddChildScheduleDialog_v2.tsx
+++ b/src/web/src/features/schedules/AddChildScheduleDialog_v2.tsx
@@ -1,6 +1,5 @@
 import { useForm, type SubmitHandler, useFieldArray } from "react-hook-form";
-import { FormContainer } from "react-hook-form-mui";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
+import { Form, FormDatePicker } from "@components/forms";
 import Button from "@mui/material/Button";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
@@ -710,7 +709,7 @@ export const AddChildScheduleDialogV2 = NiceModal.create<AddChildScheduleDialogP
         </DialogTitle>
 
         <DialogContent sx={{ p: 0, backgroundColor: "#f8f9fa", position: "relative" }}>
-          <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
+          <Form formContext={formContext} onSubmit={onSubmit}>
             {/* Date Range Section */}
             <Box
               sx={{
@@ -742,7 +741,7 @@ export const AddChildScheduleDialogV2 = NiceModal.create<AddChildScheduleDialogP
               </Box>
 
               <Stack spacing={isMobile ? 2 : 3} direction={isMobile ? "column" : "row"}>
-                <DatePickerElement
+                <FormDatePicker
                   label={t("Start Date")}
                   name="startDate"
                   slotProps={{
@@ -893,7 +892,7 @@ export const AddChildScheduleDialogV2 = NiceModal.create<AddChildScheduleDialogP
                 </Stack>
               )}
             </Box>
-          </FormContainer>
+          </Form>
         </DialogContent>
 
         {/* Mobile Floating Action Button */}

--- a/src/web/src/features/schedules/EditChildScheduleDialog.tsx
+++ b/src/web/src/features/schedules/EditChildScheduleDialog.tsx
@@ -1,6 +1,5 @@
 import { useForm, type SubmitHandler, useFieldArray } from "react-hook-form";
-import { FormContainer } from "react-hook-form-mui";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
+import { Form, FormDatePicker } from "@components/forms";
 import Button from "@mui/material/Button";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
@@ -694,7 +693,7 @@ export const EditChildScheduleDialog = NiceModal.create<EditChildScheduleDialogP
         </DialogTitle>
 
         <DialogContent sx={{ p: 0, backgroundColor: "#f8f9fa", position: "relative" }}>
-          <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
+          <Form formContext={formContext} onSubmit={onSubmit}>
             {/* Date Range Section */}
             <Box
               sx={{
@@ -726,7 +725,7 @@ export const EditChildScheduleDialog = NiceModal.create<EditChildScheduleDialogP
               </Box>
 
               <Stack spacing={isMobile ? 2 : 3} direction={isMobile ? "column" : "row"}>
-                <DatePickerElement
+                <FormDatePicker
                   label={t("Start Date")}
                   name="startDate"
                   slotProps={{
@@ -831,7 +830,7 @@ export const EditChildScheduleDialog = NiceModal.create<EditChildScheduleDialogP
                 </Box>
               )}
             </Box>
-          </FormContainer>
+          </Form>
         </DialogContent>
 
         <DialogActions

--- a/src/web/src/features/schedules/EditChildScheduleDialog.tsx
+++ b/src/web/src/features/schedules/EditChildScheduleDialog.tsx
@@ -742,7 +742,7 @@ export const EditChildScheduleDialog = NiceModal.create<EditChildScheduleDialogP
                     },
                   }}
                   transform={{
-                    input: (value) => (value ? dayjs(value) : null),
+                    input: (value) => (value ? dayjs(value as string) : null),
                     output: (value) => (value ? value.format("YYYY-MM-DD") : null),
                   }}
                 />

--- a/src/web/src/features/timeSlots/AddTimeSlotDialog.tsx
+++ b/src/web/src/features/timeSlots/AddTimeSlotDialog.tsx
@@ -1,5 +1,5 @@
-import { Controller, type SubmitHandler, useForm } from "react-hook-form";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { Form, FormTextField, FormTimeField } from "@components/forms";
 import Button from "@mui/material/Button";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
@@ -16,8 +16,6 @@ import {
   useAddTimeSlot,
 } from "@api/scheduling/endpoints/time-slots/time-slots";
 import { type AddTimeSlotCommand } from "@api/scheduling/models/addTimeSlotCommand";
-import { TimeField } from "@mui/x-date-pickers/TimeField";
-import dayjs from "dayjs";
 
 export const AddTimeSlotDialog = NiceModal.create(() => {
   const { t } = useTranslation();
@@ -27,7 +25,6 @@ export const AddTimeSlotDialog = NiceModal.create(() => {
   const formContext = useForm<AddTimeSlotCommand>();
 
   const {
-    control,
     handleSubmit,
     reset,
     setError,
@@ -70,8 +67,8 @@ export const AddTimeSlotDialog = NiceModal.create(() => {
         <DialogContentText>
           {t("To add a time slot, please specify the name here and start and end times.")}
         </DialogContentText>
-        <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
-          <TextFieldElement
+        <Form formContext={formContext} onSubmit={onSubmit}>
+          <FormTextField
             autoFocus
             name="name"
             label={t("Name")}
@@ -80,41 +77,19 @@ export const AddTimeSlotDialog = NiceModal.create(() => {
             autoComplete="off"
             fullWidth
           />
-          <Controller
-            control={control}
+          <FormTimeField
             name="startTime"
-            render={({ field }) => (
-              <TimeField
-                label={t("Start time")}
-                defaultValue={field.value ? dayjs(field.value) : undefined}
-                inputRef={field.ref}
-                format="HH:mm"
-                variant="standard"
-                onChange={(date) => {
-                  field.onChange(date?.format("HH:mm:ss"));
-                }}
-                fullWidth
-              />
-            )}
+            label={t("Start time")}
+            variant="standard"
+            fullWidth
           />
-          <Controller
-            control={control}
+          <FormTimeField
             name="endTime"
-            render={({ field }) => (
-              <TimeField
-                label={t("End time")}
-                defaultValue={field.value ? dayjs(field.value) : undefined}
-                inputRef={field.ref}
-                format="HH:mm"
-                variant="standard"
-                onChange={(date) => {
-                  field.onChange(date?.format("HH:mm:ss"));
-                }}
-                fullWidth
-              />
-            )}
+            label={t("End time")}
+            variant="standard"
+            fullWidth
           />
-        </FormContainer>
+        </Form>
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleOnCancelClick}>

--- a/src/web/src/features/timeSlots/EditTimeSlotDialog.tsx
+++ b/src/web/src/features/timeSlots/EditTimeSlotDialog.tsx
@@ -1,5 +1,5 @@
-import { Controller, type SubmitHandler, useForm } from "react-hook-form";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { Form, FormTextField, FormTimeField } from "@components/forms";
 import Button from "@mui/material/Button";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
@@ -18,7 +18,6 @@ import {
 } from "@api/scheduling/endpoints/time-slots/time-slots";
 import { type UpdateTimeSlotCommand } from "@api/scheduling/models/updateTimeSlotCommand";
 import { type TimeSlotListVM } from "@api/scheduling/models/timeSlotListVM";
-import { TimeField } from "@mui/x-date-pickers/TimeField";
 import dayjs from "dayjs";
 
 type EditTimeSlotDialogProps = {
@@ -42,7 +41,6 @@ const EditTimeSlotDialog = NiceModal.create<EditTimeSlotDialogProps>(({ timeSlot
   });
 
   const {
-    control,
     handleSubmit,
     reset,
     setError,
@@ -87,8 +85,8 @@ const EditTimeSlotDialog = NiceModal.create<EditTimeSlotDialogProps>(({ timeSlot
       <DialogTitle>{t("Edit time slot")}</DialogTitle>
       <DialogContent>
         <DialogContentText>{t("Update the time slot details below.")}</DialogContentText>
-        <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
-          <TextFieldElement
+        <Form formContext={formContext} onSubmit={onSubmit}>
+          <FormTextField
             autoFocus
             name="name"
             label={t("Name")}
@@ -108,35 +106,18 @@ const EditTimeSlotDialog = NiceModal.create<EditTimeSlotDialogProps>(({ timeSlot
               },
             }}
           />
-          <Controller
-            control={control}
+          <FormTimeField
             name="startTime"
-            rules={{
-              required: t("Start time is required"),
-            }}
-            render={({ field, fieldState }) => (
-              <TimeField
-                label={t("Start time")}
-                defaultValue={field.value ? dayjs(field.value, "HH:mm:ss") : undefined}
-                inputRef={field.ref}
-                format="HH:mm"
-                variant="standard"
-                onChange={(date) => {
-                  field.onChange(date?.format("HH:mm:ss"));
-                }}
-                fullWidth
-                slotProps={{
-                  textField: {
-                    error: !!fieldState.error,
-                    helperText: fieldState.error?.message,
-                  },
-                }}
-              />
-            )}
+            label={t("Start time")}
+            variant="standard"
+            fullWidth
+            rules={{ required: t("Start time is required") }}
           />
-          <Controller
-            control={control}
+          <FormTimeField
             name="endTime"
+            label={t("End time")}
+            variant="standard"
+            fullWidth
             rules={{
               required: t("End time is required"),
               validate: (value, formValues) => {
@@ -146,27 +127,8 @@ const EditTimeSlotDialog = NiceModal.create<EditTimeSlotDialogProps>(({ timeSlot
                 return endTime.isAfter(startTime) || t("End time must be after start time");
               },
             }}
-            render={({ field, fieldState }) => (
-              <TimeField
-                label={t("End time")}
-                defaultValue={field.value ? dayjs(field.value, "HH:mm:ss") : undefined}
-                inputRef={field.ref}
-                format="HH:mm"
-                variant="standard"
-                onChange={(date) => {
-                  field.onChange(date?.format("HH:mm:ss"));
-                }}
-                fullWidth
-                slotProps={{
-                  textField: {
-                    error: !!fieldState.error,
-                    helperText: fieldState.error?.message,
-                  },
-                }}
-              />
-            )}
           />
-        </FormContainer>
+        </Form>
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleOnCancelClick}>

--- a/src/web/src/pages/children/NewChildPage.tsx
+++ b/src/web/src/pages/children/NewChildPage.tsx
@@ -1,6 +1,6 @@
 import { type AddChildCommand } from "@api/crm/models/addChildCommand";
 import { useForm } from "react-hook-form";
-import { FormContainer, TextFieldElement } from "react-hook-form-mui";
+import { Form, FormDatePicker, FormTextField } from "@components/forms";
 import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import Grid from "@mui/material/Grid";
@@ -9,7 +9,6 @@ import { getListChildrenQueryKey, useAddChild } from "@api/crm/endpoints/childre
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { DatePickerElement } from "react-hook-form-mui/date-pickers";
 import { type UnprocessableEntityResponse } from "@api/crm/models/unprocessableEntityResponse";
 
 const NewChildPage = () => {
@@ -50,23 +49,21 @@ const NewChildPage = () => {
         <Alert severity="info" sx={{ mb: 2 }}>
           {t("A unique child identification number will be automatically assigned when you save.")}
         </Alert>
-        <FormContainer formContext={formContext} handleSubmit={handleSubmit(onSubmit)}>
+        <Form formContext={formContext} onSubmit={onSubmit}>
           <Grid container alignItems="flex-start" spacing={2}>
             <Grid size={12}>
-              <TextFieldElement name="givenName" label={t("Voornaam")} required fullWidth />
+              <FormTextField name="givenName" label={t("Voornaam")} required fullWidth />
             </Grid>
             <Grid size={12}>
-              <TextFieldElement name="familyName" label={t("Achternaam")} required fullWidth />
+              <FormTextField name="familyName" label={t("Achternaam")} required fullWidth />
             </Grid>
             <Grid size={12}>
-              <DatePickerElement
+              <FormDatePicker
                 label={t("Date of birth")}
                 name="dateOfBirth"
                 required
                 transform={{
-                  output: (value) => {
-                    return value ? value.format("YYYY-MM-DD") : null;
-                  },
+                  output: (value) => (value ? value.format("YYYY-MM-DD") : null),
                 }}
                 slotProps={{
                   textField: {
@@ -77,11 +74,11 @@ const NewChildPage = () => {
               />
             </Grid>
             <Grid size={12}>
-              <TextFieldElement name="CID" label={t("CID")} fullWidth />
+              <FormTextField name="CID" label={t("CID")} fullWidth />
             </Grid>
           </Grid>
           <Button onClick={handleSubmit(onSubmit)}>{t("Save", { ns: "common" })}</Button>
-        </FormContainer>
+        </Form>
       </Paper>
     </>
   );

--- a/src/web/src/pages/children/NewChildPage.tsx
+++ b/src/web/src/pages/children/NewChildPage.tsx
@@ -67,7 +67,6 @@ const NewChildPage = () => {
                 }}
                 slotProps={{
                   textField: {
-                    size: "small",
                     fullWidth: true,
                   },
                 }}


### PR DESCRIPTION
Add reusable Form, FormTextField, FormDatePicker, FormSelect and FormTimeField primitives under src/components/forms. These wrap react-hook-form Controller + MUI components directly and expose a consistent API without the third-party adapter library.

Migrate all consumers:
- components/child/BasicInformationCard
- components/guardian/GuardianBasicInformationCard
- components/guardian/GuardianContactInformationCard
- features/absence/AddAbsenceDialog
- features/closurePeriods/AddClosurePeriodDialog
- features/groups/AddGroupDialog
- features/guardians/GuardianForm
- features/schedules/AddChildScheduleDialog_v2
- features/schedules/EditChildScheduleDialog
- features/timeSlots/AddTimeSlotDialog
- features/timeSlots/EditTimeSlotDialog
- pages/children/NewChildPage

Remove react-hook-form-mui from package.json and update lockfile.