### PR TITLE
Group React Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
       mui:
         patterns:
           - "@mui/*"


### PR DESCRIPTION
## Summary
- group `react` and `react-dom` Dependabot updates for the web npm project
- keep the existing MUI Dependabot grouping unchanged

## Testing
- Not run; configuration-only change.