### PR TITLE
chore(deps): add 48-hour cooldown to all Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default: "2 days"
 
   - package-ecosystem: "npm"
     directory: "src/web"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default: "2 days"
     groups:
       react:
         patterns:
@@ -39,6 +43,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default: "2 days"
     groups:
       masstransit:
         patterns:
@@ -57,3 +63,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    cooldown:
+      default: "2 days"


### PR DESCRIPTION
## What

Adds a `cooldown.default: "2 days"` to all four Dependabot ecosystems (`github-actions`, `npm`, `nuget`, `docker`).

## Why

A 48-hour cooldown prevents Dependabot from immediately opening PRs for newly released packages. This reduces noise from packages that are quickly patched, yanked, or have post-release issues discovered within the first couple of days.

## Changes

- `.github/dependabot.yml` — added `cooldown: default: "2 days"` to `github-actions`, `npm`, `nuget`, and `docker` ecosystems