### PR TITLE
fix(deps): use correct cooldown syntax (default-days)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     cooldown:
-      default: "2 days"
+      default-days: 2
 
   - package-ecosystem: "npm"
     directory: "src/web"
@@ -26,7 +26,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     cooldown:
-      default: "2 days"
+      default-days: 2
     groups:
       react:
         patterns:
@@ -44,7 +44,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     cooldown:
-      default: "2 days"
+      default-days: 2
     groups:
       masstransit:
         patterns:
@@ -64,4 +64,4 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 3
     cooldown:
-      default: "2 days"
+      default-days: 2


### PR DESCRIPTION
## What

Fixes the `cooldown` configuration in `.github/dependabot.yml` that was merged in #643.

## Why

The previous PR used `default: "2 days"` which is not a valid Dependabot schema property and caused a validation error. The correct parameter is `default-days` with a numeric value (1–90).

## Changes

- `.github/dependabot.yml` — changed `default: "2 days"` → `default-days: 2` for all four ecosystems (`github-actions`, `npm`, `nuget`, `docker`)