### PR TITLE
fix: resolve ESLint errors from eslint-plugin-react-hooks 7.1.x upgrade

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -79,7 +79,7 @@
     "eslint": "~10.4.1",
     "eslint-plugin-i18next": "^6.1.4",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
     "i18next-parser": "^9.4.0",

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react-hooks:
-        specifier: ^7.0.1
-        version: 7.0.1(eslint@10.4.1(jiti@2.7.0))
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.4.1(jiti@2.7.0))
@@ -304,11 +304,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -2553,11 +2548,11 @@ packages:
     resolution: {integrity: sha512-BekXQu1VaVFkREepQGsntBYoKuPsf89V16n/s2xpKMtsw0/lDseds1wBhj3RtO1dKnHsfTPaG+xul1vF0R7LEQ==}
     engines: {node: '>=18.10.0'}
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-refresh@0.5.2:
     resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
@@ -4613,9 +4608,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -4796,10 +4788,6 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.0':
-    dependencies:
       '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
@@ -7101,14 +7089,14 @@ snapshots:
       lodash: 4.18.1
       requireindex: 1.1.0
 
-  eslint-plugin-react-hooks@7.0.1(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       eslint: 10.4.1(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9361,10 +9349,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
-
-  zod@4.3.6: {}
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/src/web/src/features/guardians/LinkExistingGuardianDialog.tsx
+++ b/src/web/src/features/guardians/LinkExistingGuardianDialog.tsx
@@ -87,7 +87,6 @@ export const LinkExistingGuardianDialog = ({
     handleSubmit,
     formState: { errors },
     reset,
-    watch,
   } = useForm<LinkGuardianFormData>({
     defaultValues: {
       guardianId: "",
@@ -96,8 +95,6 @@ export const LinkExistingGuardianDialog = ({
       isEmergencyContact: false,
     },
   });
-
-  const watchedGuardianId = watch("guardianId");
 
   const handleFormSubmit = async (data: LinkGuardianFormData) => {
     try {
@@ -351,7 +348,7 @@ export const LinkExistingGuardianDialog = ({
           <Button
             type="submit"
             variant="contained"
-            disabled={linkMutation.isPending || !watchedGuardianId}
+            disabled={linkMutation.isPending || !selectedGuardian}
           >
             {linkMutation.isPending ? t("Linking...") : t("Link Guardian")}
           </Button>

--- a/src/web/src/features/settings/EndMarkSettingsCard.tsx
+++ b/src/web/src/features/settings/EndMarkSettingsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Card,
   CardContent,
@@ -25,34 +25,25 @@ export const EndMarkSettingsCard: React.FC = () => {
   const { data: settings, isLoading, error, refetch } = useGetEndMarkSettings();
   const updateMutation = useUpdateEndMarkSettings();
 
-  // Form state
-  const [formData, setFormData] = useState<UpdateEndMarkSettingsCommand>({
-    isEnabled: settings?.isEnabled ?? false,
-    yearsAfterBirth: settings?.yearsAfterBirth ?? 5,
-    description: settings?.description ?? "EndMark for {childName} born on {birthDate}",
-  });
+  // Track only local user changes; merge with server state for display
+  const [localChanges, setLocalChanges] = useState<Partial<UpdateEndMarkSettingsCommand>>({});
 
-  // Track if form has been modified
-  const [isModified, setIsModified] = useState(false);
+  const isModified = Object.keys(localChanges).length > 0;
 
-  // Update form data when settings are loaded
-  React.useEffect(() => {
-    if (settings) {
-      const newFormData = {
-        isEnabled: settings.isEnabled ?? false,
-        yearsAfterBirth: settings.yearsAfterBirth ?? 5,
-        description: settings.description ?? "EndMark for {childName} born on {birthDate}",
-      };
-      setFormData(newFormData);
-      setIsModified(false);
-    }
-  }, [settings]);
+  const formData: UpdateEndMarkSettingsCommand = {
+    isEnabled: localChanges.isEnabled ?? settings?.isEnabled ?? false,
+    yearsAfterBirth: localChanges.yearsAfterBirth ?? settings?.yearsAfterBirth ?? 5,
+    description:
+      localChanges.description ??
+      settings?.description ??
+      "EndMark for {childName} born on {birthDate}",
+  };
 
   const handleSave = async () => {
     try {
       await updateMutation.mutateAsync({ data: formData });
       await refetch();
-      setIsModified(false);
+      setLocalChanges({});
     } catch (error) {
       console.error("Failed to update EndMark settings:", error);
     }
@@ -67,11 +58,10 @@ export const EndMarkSettingsCard: React.FC = () => {
             ? parseInt(event.target.value, 10) || 0
             : event.target.value;
 
-      setFormData((prev) => ({
+      setLocalChanges((prev) => ({
         ...prev,
         [field]: value,
       }));
-      setIsModified(true);
     };
 
   if (isLoading) {

--- a/src/web/src/hooks/useChildrenListState.ts
+++ b/src/web/src/hooks/useChildrenListState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { type DataGridProps, type GridPaginationModel } from "@mui/x-data-grid";
 
@@ -19,61 +19,74 @@ const parsePositiveInt = (value: string | null, fallback: number) => {
 export const useChildrenListState = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Initial state from URL or localStorage
-  const [state, setState] = useState<ChildrenListState>(() => {
-    const ls = localStorage.getItem(STORAGE_KEY);
-    let fromStorage: Partial<ChildrenListState> = {};
-    if (ls) {
-      try {
-        fromStorage = JSON.parse(ls);
-      } catch {
-        /* ignore */
+  // Derive state directly from URL params — no local state needed
+  const state = useMemo<ChildrenListState>(
+    () => ({
+      pageNumber: parsePositiveInt(searchParams.get("page"), 1),
+      pageSize: parsePositiveInt(searchParams.get("size"), 10),
+      search: searchParams.get("q") ?? "",
+    }),
+    [searchParams],
+  );
+
+  // Initialize URL from localStorage on first mount if URL has no params
+  useEffect(() => {
+    if (!searchParams.has("page") && !searchParams.has("size")) {
+      const ls = localStorage.getItem(STORAGE_KEY);
+      if (ls) {
+        try {
+          const fromStorage: Partial<ChildrenListState> = JSON.parse(ls);
+          const params = new URLSearchParams(searchParams);
+          params.set("page", String(fromStorage.pageNumber ?? 1));
+          params.set("size", String(fromStorage.pageSize ?? 10));
+          if (fromStorage.search) params.set("q", fromStorage.search);
+          setSearchParams(params, { replace: true });
+        } catch {
+          /* ignore */
+        }
       }
     }
-
-    return {
-      pageNumber: parsePositiveInt(searchParams.get("page"), fromStorage.pageNumber ?? 1),
-      pageSize: parsePositiveInt(searchParams.get("size"), fromStorage.pageSize ?? 10),
-      search: searchParams.get("q") ?? fromStorage.search ?? "",
-    };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Persist to localStorage
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   }, [state]);
 
-  // Sync URL (replace to avoid history spam)
-  useEffect(() => {
-    const params = new URLSearchParams(searchParams);
-    params.set("page", state.pageNumber.toString());
-    params.set("size", state.pageSize.toString());
-    if (state.search) params.set("q", state.search);
-    else params.delete("q");
-    setSearchParams(params, { replace: true });
-  }, [state, searchParams, setSearchParams]);
+  const onPaginationModelChange = useCallback(
+    (model: GridPaginationModel) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set("page", String(model.page + 1));
+          params.set("size", String(model.pageSize));
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
-  // React to external URL changes (e.g. another hook instance updated params)
-  useEffect(() => {
-    const spPage = parsePositiveInt(searchParams.get("page"), state.pageNumber);
-    const spSize = parsePositiveInt(searchParams.get("size"), state.pageSize);
-    const spSearch = searchParams.get("q") ?? "";
-    if (spPage !== state.pageNumber || spSize !== state.pageSize || spSearch !== state.search) {
-      setState({ pageNumber: spPage, pageSize: spSize, search: spSearch });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
-
-  const onPaginationModelChange = useCallback((model: GridPaginationModel) => {
-    setState((s) => ({ ...s, pageNumber: model.page + 1, pageSize: model.pageSize }));
-  }, []);
-
-  const setSearch = useCallback((value: string) => {
-    setState((s) => ({ ...s, pageNumber: 1, search: value }));
-  }, []);
+  const setSearch = useCallback(
+    (value: string) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set("page", "1");
+          if (value) params.set("q", value);
+          else params.delete("q");
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const apiParams = useMemo(() => {
-    const p: Record<string, any> = {
+    const p: Record<string, unknown> = {
       pageNumber: state.pageNumber,
       pageSize: state.pageSize,
     };

--- a/src/web/src/hooks/useGuardiansListState.ts
+++ b/src/web/src/hooks/useGuardiansListState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { type DataGridProps, type GridPaginationModel } from "@mui/x-data-grid";
 
@@ -19,57 +19,71 @@ const parsePositiveInt = (value: string | null, fallback: number) => {
 export const useGuardiansListState = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Initial state from URL or localStorage
-  const [state, setState] = useState<GuardiansListState>(() => {
-    const ls = localStorage.getItem(STORAGE_KEY);
-    let fromStorage: Partial<GuardiansListState> = {};
-    if (ls) {
-      try {
-        fromStorage = JSON.parse(ls);
-      } catch {
-        /* ignore */
+  // Derive state directly from URL params — no local state needed
+  const state = useMemo<GuardiansListState>(
+    () => ({
+      pageNumber: parsePositiveInt(searchParams.get("page"), 1),
+      pageSize: parsePositiveInt(searchParams.get("size"), 10),
+      search: searchParams.get("q") ?? "",
+    }),
+    [searchParams],
+  );
+
+  // Initialize URL from localStorage on first mount if URL has no params
+  useEffect(() => {
+    if (!searchParams.has("page") && !searchParams.has("size")) {
+      const ls = localStorage.getItem(STORAGE_KEY);
+      if (ls) {
+        try {
+          const fromStorage: Partial<GuardiansListState> = JSON.parse(ls);
+          const params = new URLSearchParams(searchParams);
+          params.set("page", String(fromStorage.pageNumber ?? 1));
+          params.set("size", String(fromStorage.pageSize ?? 10));
+          if (fromStorage.search) params.set("q", fromStorage.search);
+          setSearchParams(params, { replace: true });
+        } catch {
+          /* ignore */
+        }
       }
     }
-    return {
-      pageNumber: parsePositiveInt(searchParams.get("page"), fromStorage.pageNumber ?? 1),
-      pageSize: parsePositiveInt(searchParams.get("size"), fromStorage.pageSize ?? 10),
-      search: searchParams.get("q") ?? fromStorage.search ?? "",
-    };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Persist to localStorage
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   }, [state]);
 
-  // Sync URL (replace to avoid history spam)
-  useEffect(() => {
-    const params = new URLSearchParams(searchParams);
-    params.set("page", state.pageNumber.toString());
-    params.set("size", state.pageSize.toString());
-    if (state.search) params.set("q", state.search);
-    else params.delete("q");
-    setSearchParams(params, { replace: true });
-  }, [state, searchParams, setSearchParams]);
+  const onPaginationModelChange = useCallback(
+    (model: GridPaginationModel) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set("page", String(model.page + 1));
+          params.set("size", String(model.pageSize));
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
-  // React to external URL changes (e.g. another hook instance updated params)
-  useEffect(() => {
-    const spPage = parsePositiveInt(searchParams.get("page"), state.pageNumber);
-    const spSize = parsePositiveInt(searchParams.get("size"), state.pageSize);
-    const spSearch = searchParams.get("q") ?? "";
-    if (spPage !== state.pageNumber || spSize !== state.pageSize || spSearch !== state.search) {
-      setState({ pageNumber: spPage, pageSize: spSize, search: spSearch });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
-
-  const onPaginationModelChange = useCallback((model: GridPaginationModel) => {
-    setState((s) => ({ ...s, pageNumber: model.page + 1, pageSize: model.pageSize }));
-  }, []);
-
-  const setSearch = useCallback((value: string) => {
-    setState((s) => ({ ...s, pageNumber: 1, search: value }));
-  }, []);
+  const setSearch = useCallback(
+    (value: string) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set("page", "1");
+          if (value) params.set("q", value);
+          else params.delete("q");
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const apiParams = useMemo(() => {
     const p: { pageNumber: number; pageSize: number; search?: string } = {


### PR DESCRIPTION
Fixes ESLint errors introduced by the `eslint-plugin-react-hooks` bump from 7.0.1 → 7.1.1 (PR #640). The new version adds stricter `set-state-in-effect` and `incompatible-library` rules.

## Changes

### `EndMarkSettingsCard.tsx` — `set-state-in-effect`
Replaced the `useEffect` that synced server `settings` into local `formData` state with a `localChanges` object (only user edits) merged with the server data at render time. No effect needed.

### `useChildrenListState.ts` & `useGuardiansListState.ts` — `set-state-in-effect`
Eliminated the circular two-way sync between local state and URL params. State is now derived directly from `searchParams` via `useMemo`. Pagination/search updates write directly to the URL via `setSearchParams`. A one-time mount effect initializes the URL from localStorage when no URL params are present.

### `LinkExistingGuardianDialog.tsx` — `incompatible-library` warning
Removed `watch("guardianId")` from react-hook-form (flagged as unmemoizable by the new plugin). The submit button's disabled state now uses the existing `selectedGuardian` state instead — semantically identical.