### PR TITLE
fix(docker): pin postgres to v17

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "8001:8001"
 
   postgres:
-    image: postgres:latest
+    image: postgres:17
   
   rabbitmq:
     image: rabbitmq:4-management


### PR DESCRIPTION
`postgres:latest` floated up to PostgreSQL 18, which moved its default data directory and refuses to start against the existing /var/lib/postgresql/data volume mount, taking down the db (and with it the migrators and scheduling-api) on docker compose up. Pin to a stable major version compatible with the current volume layout.