### PR TITLE
test(e2e): Playwright e2e suite covering all use cases, self-contained in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,123 @@
+name: e2e
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+    paths:
+    - src/**
+    - tests/e2e/**
+    - .github/workflows/e2e.yml
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6.0.3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    # Build all stack images with GitHub Actions layer caching. Bake reads the
+    # compose files, so image definitions stay in one place.
+    - name: Build stack images
+      working-directory: ./src
+      env:
+        NUGET_GITHUB_TOKEN: ${{ secrets.NUGET_GITHUB_TOKEN }}
+      run: |
+        docker buildx bake \
+          -f docker-compose.yml -f docker-compose.e2e.yml \
+          --load \
+          $(for s in web crm-api crm-migrator scheduling-api scheduling-migrator; do
+              echo "--set $s.cache-from=type=gha,scope=e2e-$s --set $s.cache-to=type=gha,scope=e2e-$s,mode=max"
+            done) \
+          web crm-api crm-migrator scheduling-api scheduling-migrator
+
+    - name: Start stack
+      working-directory: ./src
+      run: |
+        docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d \
+          mock-auth envoy postgres rabbitmq web \
+          crm-migrator crm-api scheduling-migrator scheduling-api
+
+    - uses: pnpm/action-setup@v6
+      with:
+        version: 11.0.8
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24.x'
+        cache: 'pnpm'
+        cache-dependency-path: tests/e2e/pnpm-lock.yaml
+
+    - name: Install dependencies
+      working-directory: ./tests/e2e
+      run: pnpm install --frozen-lockfile
+
+    - name: Resolve Playwright version
+      id: pw-version
+      working-directory: ./tests/e2e
+      run: |
+        version=$(pnpm exec playwright --version | awk '{print $2}')
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: pw-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-chromium
+
+    - name: Install Playwright Chromium
+      if: steps.pw-cache.outputs.cache-hit != 'true'
+      working-directory: ./tests/e2e
+      run: pnpm exec playwright install --with-deps chromium
+
+    - name: Install Chromium system deps only
+      if: steps.pw-cache.outputs.cache-hit == 'true'
+      working-directory: ./tests/e2e
+      run: pnpm exec playwright install-deps chromium
+
+    # The Playwright global setup polls mock-auth, the web app and both APIs
+    # (authenticated) until the whole stack — including migrations — is ready.
+    - name: Run e2e tests
+      working-directory: ./tests/e2e
+      env:
+        CI: 'true'
+      run: pnpm exec playwright test
+
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: playwright-report
+        path: |
+          tests/e2e/playwright-report
+          tests/e2e/test-results
+        if-no-files-found: ignore
+        retention-days: 14
+
+    - name: Collect stack logs
+      if: failure()
+      working-directory: ./src
+      run: |
+        docker compose -f docker-compose.yml -f docker-compose.e2e.yml logs --no-color > /tmp/stack-logs.txt 2>&1 || true
+
+    - name: Upload stack logs
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: stack-logs
+        path: /tmp/stack-logs.txt
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ autom4te.cache/
 *.tar.gz
 tarballs/
 test-results/
+playwright-report/
 
 # Mac bundle stuff
 *.dmg

--- a/docs/e2e-use-cases.md
+++ b/docs/e2e-use-cases.md
@@ -1,0 +1,96 @@
+# KDVManager — Use Cases & E2E Test Coverage
+
+A catalog of all user-facing use cases in the application, derived from the
+frontend routes/pages and the CRM + Scheduling APIs, and how the Playwright
+e2e suite (`tests/e2e/`) covers them.
+
+## 1. Authentication
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 1.1 | Unauthenticated visitor is sent through the login flow and lands in the app (root redirects to `/schedule`) | `auth.spec.ts` |
+| 1.2 | Deep links are preserved through the login bounce (`returnTo`) | `auth.spec.ts` |
+| 1.3 | Authenticated user can log out via the account menu | `auth.spec.ts` |
+
+## 2. Daily schedule overview (`/schedule`)
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 2.1 | View the daily schedule: groups as columns, scheduled children listed per group | `schedule-overview.spec.ts` |
+| 2.2 | Navigate dates: previous/next day, "Vandaag" (today), date in URL (`?date=`) | `schedule-overview.spec.ts` |
+| 2.3 | Closed days show the closure reason and no child schedules | `schedule-overview.spec.ts` |
+| 2.4 | Absent children are indicated in the group's daily summary | `schedule-overview.spec.ts` |
+
+## 3. Child management (`/children`)
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 3.1 | List children (server-paginated DataGrid) | `children.spec.ts` |
+| 3.2 | Search children by name (debounced, `?q=` URL param) | `children.spec.ts` |
+| 3.3 | Create a child (given name, family name, date of birth) → redirected to detail page | `children.spec.ts` |
+| 3.4 | Edit child details (edit-in-place on the Basisinformatie card) | `children.spec.ts` |
+| 3.5 | Delete a child from the list (with confirmation dialog) | `children.spec.ts` |
+
+## 4. Child planning (`/children/:id/planning`)
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 4.1 | View a child's schedules and end marks on the planning tab | `child-planning.spec.ts` |
+| 4.2 | Add a schedule via the dialog (start date + rules: weekday, time slot, group) | `child-planning.spec.ts` |
+| 4.3 | Add an end mark for a child | `child-planning.spec.ts` |
+| 4.4 | Delete a schedule from the planning tab | `child-planning.spec.ts` |
+| 4.5 | Automatic system end marks are created when a child is registered (EndMark automation) | implicitly exercised by `child-planning.spec.ts` (asserts around the auto-generated end mark) |
+
+## 5. Guardian management (`/guardians`)
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 5.1 | List guardians (server-paginated DataGrid) + search by name | `guardians.spec.ts` |
+| 5.2 | Create a guardian (name, email, …) | `guardians.spec.ts` |
+| 5.3 | Edit guardian details (edit-in-place) | `guardians.spec.ts` |
+| 5.4 | Link a child to a guardian with a relationship type (via child detail page) | `guardians.spec.ts` |
+| 5.5 | Unlink a child from a guardian (with confirmation) | `guardians.spec.ts` |
+| 5.6 | Delete a guardian (with confirmation) | `guardians.spec.ts` |
+
+## 6. Reporting
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 6.1 | Newsletter recipients: active children's guardians with emails, filtered by month/year | `reports.spec.ts` |
+| 6.2 | Print attendance schedules per group for a month (in-page A4 preview + print) | `reports.spec.ts` |
+| 6.3 | Phone list of guardians per child (preview + PDF export) | `reports.spec.ts` |
+
+## 7. Settings
+
+| # | Use case | Covered by |
+|---|----------|-----------|
+| 7.1 | Settings hub shows cards and navigates to sub-pages | `settings.spec.ts` |
+| 7.2 | Groups: add via dialog, list, delete with confirmation | `settings-groups.spec.ts` |
+| 7.3 | Time slots: add via dialog (name, start/end time), edit, delete | `settings-timeslots.spec.ts` |
+| 7.4 | Closure periods: add via dialog (start/end date, reason), list, delete | `settings-closure-periods.spec.ts` |
+| 7.5 | End-mark automation settings: view and update (years after birth) | `settings.spec.ts` |
+
+## Cross-cutting behaviors exercised throughout
+
+- **Auth0 JWT chain**: every test runs through the real Envoy JWT filter and
+  .NET JWT validation (against the local mock issuer) — see
+  `tests/e2e/mock-auth/server.mjs`.
+- **Multi-tenancy**: all data is created under the fixed e2e tenant claim
+  (`https://kdvmanager.nl/tenant`).
+- **CRM → Scheduling replication**: children created in CRM reach the
+  Scheduling service asynchronously over RabbitMQ; schedule-related tests wait
+  for this (e.g. `Api.createSchedule` retries).
+- **Dutch i18n**: assertions use the real `nl` translations from
+  `src/web/src/locales/nl/`.
+
+## Known gaps (not covered)
+
+- Real Auth0 Universal Login UI (replaced by the mock; the SPA-side flow —
+  redirect, callback, silent auth, refresh tokens, logout — *is* covered).
+- PDF binary content of print/phone-list exports (generation is triggered and
+  the in-page data is asserted, but the PDFs are not parsed).
+- Mobile/responsive variants of pages (tests run desktop Chromium only).
+- Child absences management UI (absence is seeded via API and asserted on the
+  schedule overview; if/where the UI offers absence creation it is untested).
+- DataGrid pagination interaction beyond control presence (would require
+  seeding >10 rows per list).

--- a/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
+++ b/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
@@ -1,0 +1,132 @@
+# Envoy config for e2e tests: identical routing to envoy.yaml, but JWTs are
+# validated against the local mock-auth OIDC server instead of Auth0, and
+# OpenTelemetry tracing is disabled.
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          upgrade_configs:
+          - upgrade_type: websocket
+          route_config:
+            name: kdvmanager_backend_route
+            virtual_hosts:
+            - name: kdvmanager_backend
+              domains:
+              - "*"
+              typed_per_filter_config:
+                envoy.filters.http.cors:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allow_origin_string_match:
+                  - safe_regex:
+                      regex: ".*"
+                  allow_headers: content-type,authorization
+                  allow_methods: GET, POST, PUT, HEAD, OPTIONS, DELETE
+                  expose_headers: x-Total
+              routes:
+              - name: "crm"
+                match:
+                  prefix: /crm/
+                route:
+                  prefix_rewrite: /
+                  cluster: crm-api
+              - name: "scheduling"
+                match:
+                  prefix: /scheduling/
+                route:
+                  prefix_rewrite: /
+                  cluster: scheduling-api
+          http_filters:
+          - name: envoy.filters.http.cors
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+          - name: envoy.filters.http.jwt_authn
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+              providers:
+                mock_auth_provider:
+                  issuer: http://localhost:5300/
+                  audiences:
+                  - https://api.kdvmanager.nl/
+                  - https://api.kdvmanager.nl
+                  remote_jwks:
+                    http_uri:
+                      uri: http://mock-auth:5300/.well-known/jwks.json
+                      cluster: mock-auth
+                      timeout: 5s
+                    cache_duration: 300s
+                  from_headers:
+                  - name: Authorization
+                    value_prefix: "Bearer "
+                  forward: true
+                  payload_in_metadata: jwt_payload
+              rules:
+              - match:
+                  prefix: /crm/openapi/
+              - match:
+                  prefix: /scheduling/swagger/
+              - match:
+                  prefix: /crm/
+                requires:
+                  provider_name: mock_auth_provider
+              - match:
+                  prefix: /scheduling/
+                requires:
+                  provider_name: mock_auth_provider
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: mock-auth
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: mock-auth
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: mock-auth
+                port_value: 5300
+  - name: crm-api
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: crm-api
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: crm-api
+                port_value: 80
+  - name: scheduling-api
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: scheduling-api
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: scheduling-api
+                port_value: 80

--- a/src/Services/CRM/Api/ConfigureServices.cs
+++ b/src/Services/CRM/Api/ConfigureServices.cs
@@ -73,13 +73,15 @@ public static class ConfigureServices
             });
         });
 
-        string domain = $"https://{configuration["Auth0:Domain"]}/";
+        // Auth0:Authority overrides the Auth0:Domain-derived authority (lets e2e tests point at a local mock issuer)
+        string authority = configuration["Auth0:Authority"] ?? $"https://{configuration["Auth0:Domain"]}/";
         services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                     .AddJwtBearer(options =>
                     {
-                        options.Authority = domain;
+                        options.Authority = authority;
                         options.Audience = configuration["Auth0:Audience"];
+                        options.RequireHttpsMetadata = authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
                     });
         services.AddAuthorization();
 

--- a/src/Services/Scheduling/Api/ConfigureServices.cs
+++ b/src/Services/Scheduling/Api/ConfigureServices.cs
@@ -47,16 +47,17 @@ public static class ConfigureServices
             });
         });
 
-        string domain = $"https://{configuration["Auth0:Domain"]}/";
+        // Auth0:Authority overrides the Auth0:Domain-derived authority (lets e2e tests point at a local mock issuer)
+        string authority = configuration["Auth0:Authority"] ?? $"https://{configuration["Auth0:Domain"]}/";
         services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
-                options.Authority = domain;
+                options.Authority = authority;
                 options.Audience = configuration["Auth0:Audience"];
 
                 // Production security settings
-                options.RequireHttpsMetadata = true;
+                options.RequireHttpsMetadata = authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
                 options.SaveToken = false; // Don't store tokens in AuthenticationProperties for security
                 options.IncludeErrorDetails = false; // Don't include detailed error info in production
 

--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -1,0 +1,86 @@
+# E2E test overrides. Use together with the base compose file (NOT the dev override):
+#
+#   docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d --build \
+#     envoy mock-auth web crm-api crm-migrator scheduling-api scheduling-migrator
+#
+# Differences from dev:
+#  - mock-auth replaces Auth0 (no external dependency, no secrets, auto-login)
+#  - Envoy uses envoy.e2e.yaml (JWT validation against mock-auth)
+#  - web is built against mock-auth and served with a CSP-free nginx config
+#  - postgres has no volume, so every run starts from a clean database
+services:
+  mock-auth:
+    image: node:24-alpine
+    command: ["node", "/mock-auth/server.mjs"]
+    volumes:
+      - ../tests/e2e/mock-auth/server.mjs:/mock-auth/server.mjs:ro
+    ports:
+      - "5300:5300"
+
+  envoy:
+    volumes:
+      - ./Services/ApiGateways/Envoy/config/envoy.e2e.yaml:/etc/envoy/envoy.yaml:ro
+    ports:
+      - "5200:8080"
+      - "8001:8001"
+    depends_on:
+      - mock-auth
+
+  postgres:
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_USER=sammy
+      - POSTGRES_PASSWORD=shark
+
+  rabbitmq:
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+
+  web:
+    build:
+      context: ./web
+      args:
+        VITE_APP_AUTH0_DOMAIN: http://localhost:5300
+        VITE_APP_AUTH0_CLIENT_ID: e2e-client
+        VITE_API_BASE_URL: //localhost:5200
+    volumes:
+      - ./web/nginx/nginx.e2e.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "9090:80"
+
+  crm-migrator:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__KDVManagerCRMConnectionString=Server=postgres; port=5432; database=KDVManagerCRMDB; User ID=sammy; password=shark; pooling=true
+
+  crm-api:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:80
+      - ConnectionStrings__KDVManagerCRMConnectionString=Server=postgres; port=5432; database=KDVManagerCRMDB; User ID=sammy; password=shark; pooling=true
+      - ConnectionStrings__RabbitMQ=amqp://guest:guest@rabbitmq:5672/
+      - Auth0__Authority=http://mock-auth:5300
+      - Auth0__Audience=https://api.kdvmanager.nl/
+    depends_on:
+      - postgres
+      - rabbitmq
+      - mock-auth
+
+  scheduling-migrator:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__KDVManagerSchedulingConnectionString=Server=postgres; port=5432; database=KDVManagerSchedulingDB; User ID=sammy; password=shark; pooling=true
+
+  scheduling-api:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:80
+      - ConnectionStrings__KDVManagerSchedulingConnectionString=Server=postgres; port=5432; database=KDVManagerSchedulingDB; User ID=sammy; password=shark; pooling=true
+      - ConnectionStrings__RabbitMQ=amqp://guest:guest@rabbitmq:5672/
+      - Auth0__Authority=http://mock-auth:5300
+      - Auth0__Audience=https://api.kdvmanager.nl/
+    depends_on:
+      - postgres
+      - rabbitmq
+      - mock-auth

--- a/src/web/nginx/nginx.e2e.conf
+++ b/src/web/nginx/nginx.e2e.conf
@@ -1,0 +1,24 @@
+# nginx config for e2e tests: same SPA serving as nginx.conf, but without the
+# production CSP/security headers (they pin Auth0/production domains and would
+# block the local mock-auth server and plain-http API gateway used in tests).
+server {
+  listen 80;
+  server_tokens off;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+
+  location = /index.html {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-cache" always;
+  }
+
+  error_page   500 502 503 504  /50x.html;
+
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,74 @@
+# KDVManager E2E tests
+
+Playwright end-to-end tests that run against the full stack (web, Envoy
+gateway, CRM API, Scheduling API, PostgreSQL, RabbitMQ) in docker compose —
+with Auth0 replaced by a tiny local mock OIDC server, so no external services
+or secrets are needed.
+
+See `docs/e2e-use-cases.md` for the use-case catalog and coverage map.
+
+## How auth works in e2e
+
+`mock-auth/server.mjs` is a zero-dependency OIDC provider that auto-approves
+every login as a fixed test user with the tenant claim the backend expects.
+
+- The web app is built with `VITE_APP_AUTH0_DOMAIN=http://localhost:5300`
+  (auth0-spa-js accepts a full URL as domain), so the normal Auth0 SPA flow —
+  redirect login, callback, iframe silent auth, refresh tokens, logout — runs
+  unmodified against the mock.
+- Envoy validates JWTs against the mock's JWKS (`envoy.e2e.yaml`).
+- The .NET APIs use `Auth0__Authority=http://mock-auth:5300` (a config-only
+  override; production behavior is unchanged).
+- Tests seed data straight against the APIs using a `client_credentials` token
+  from the mock (see `helpers/api.ts`).
+
+## Running locally
+
+```bash
+# 1. Start the stack (from src/). NUGET_GITHUB_TOKEN must be set for the
+#    Scheduling service build (private BKRCalculator package).
+cd src
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d --build \
+  mock-auth envoy postgres rabbitmq web \
+  crm-migrator crm-api scheduling-migrator scheduling-api
+
+# 2. Run the tests (from tests/e2e). The global setup waits for the stack
+#    (including migrations) to become ready.
+cd ../tests/e2e
+pnpm install
+pnpm exec playwright install chromium
+pnpm test
+
+# Useful variants
+pnpm test:headed          # watch the browser
+pnpm test:ui              # Playwright UI mode
+pnpm exec playwright test specs/children.spec.ts -g "search"   # one test
+pnpm report               # open the HTML report
+```
+
+Note: the e2e compose file gives postgres **no volume** — `docker compose
+... down` discards all data, which keeps runs reproducible. Don't combine
+`docker-compose.e2e.yml` with `docker-compose.override.yml` (the dev
+override); use exactly the two files shown above.
+
+## CI
+
+`.github/workflows/e2e.yml` builds the stack images (with GHA layer caching),
+starts the stack, and runs the suite. Failure artifacts: Playwright HTML
+report + traces, and the docker compose logs.
+
+## Conventions
+
+- Tests run **serially** (`workers: 1`) because they share one tenant/database.
+- All test data uses `uniqueName()` so runs never collide; specs clean up
+  after themselves via the API (best-effort, `try/catch`).
+- The UI is Dutch (`nl`); assert strings from `src/web/src/locales/nl/` —
+  `public/locales` is stale, don't use it.
+- The dockerized web app is a **production** build: MUI's
+  `data-testid="...Icon"` attributes are stripped, so don't rely on
+  `getByTestId` for MUI icons; use roles/accessible names or stable structure.
+- Children replicate from CRM to Scheduling asynchronously (RabbitMQ);
+  anything that needs the child in Scheduling must wait
+  (`Api.createSchedule` retries internally).
+- New children automatically get a system-generated end mark
+  (EndMark automation) — don't assert "no end marks" for a fresh child.

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,44 @@
+import { API_URL, MOCK_AUTH_URL, WEB_URL } from "./helpers/config";
+import { getApiToken } from "./helpers/auth";
+
+const READY_TIMEOUT_MS = 240_000;
+const POLL_INTERVAL_MS = 2_000;
+
+async function waitFor(name: string, probe: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      if (await probe()) {
+        console.log(`[global-setup] ${name} is ready`);
+        return;
+      }
+    } catch (error) {
+      lastError = String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(`[global-setup] Timed out waiting for ${name}. Last error: ${lastError}`);
+}
+
+/**
+ * Wait until the whole stack is up: mock-auth issues tokens, the web app is
+ * served, and both APIs answer authenticated requests (which also proves the
+ * database migrations have completed and the JWT chain works end to end).
+ */
+export default async function globalSetup(): Promise<void> {
+  await waitFor("mock-auth", async () => (await fetch(`${MOCK_AUTH_URL}/healthz`)).ok);
+  await waitFor("web", async () => (await fetch(WEB_URL)).ok);
+
+  const token = await getApiToken();
+  const authed = { headers: { Authorization: `Bearer ${token}` } };
+
+  await waitFor("crm-api", async () => {
+    const res = await fetch(`${API_URL}/crm/v1/children?pageNumber=1&pageSize=1`, authed);
+    return res.ok;
+  });
+  await waitFor("scheduling-api", async () => {
+    const res = await fetch(`${API_URL}/scheduling/v1/groups?pageNumber=1&pageSize=1`, authed);
+    return res.ok;
+  });
+}

--- a/tests/e2e/helpers/api.ts
+++ b/tests/e2e/helpers/api.ts
@@ -1,0 +1,171 @@
+import { request, type APIRequestContext } from "@playwright/test";
+import { API_URL } from "./config";
+import { getApiToken } from "./auth";
+
+/**
+ * Thin client for the CRM and Scheduling APIs (through the Envoy gateway),
+ * used to seed and clean up test data without going through the UI.
+ */
+export class Api {
+  private constructor(private readonly context: APIRequestContext) {}
+
+  static async create(): Promise<Api> {
+    const token = await getApiToken();
+    const context = await request.newContext({
+      baseURL: API_URL,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    });
+    return new Api(context);
+  }
+
+  async dispose(): Promise<void> {
+    await this.context.dispose();
+  }
+
+  private async post(path: string, data: unknown): Promise<string> {
+    const response = await this.context.post(path, { data });
+    if (!response.ok()) {
+      throw new Error(`POST ${path} failed: ${response.status()} ${await response.text()}`);
+    }
+    const text = await response.text();
+    // Endpoints return the created id as a JSON-encoded GUID string.
+    try {
+      return JSON.parse(text) as string;
+    } catch {
+      return text;
+    }
+  }
+
+  async delete(path: string): Promise<void> {
+    const response = await this.context.delete(path);
+    if (!response.ok()) {
+      throw new Error(`DELETE ${path} failed: ${response.status()} ${await response.text()}`);
+    }
+  }
+
+  async get<T>(path: string): Promise<T> {
+    const response = await this.context.get(path);
+    if (!response.ok()) {
+      throw new Error(`GET ${path} failed: ${response.status()} ${await response.text()}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  // --- CRM ---
+
+  async createChild(child: {
+    givenName: string;
+    familyName: string;
+    dateOfBirth: string; // YYYY-MM-DD
+    cid?: string;
+  }): Promise<string> {
+    return this.post("/crm/v1/children", child);
+  }
+
+  async deleteChild(id: string): Promise<void> {
+    await this.delete(`/crm/v1/children/${id}`);
+  }
+
+  async createGuardian(guardian: {
+    givenName: string;
+    familyName: string;
+    dateOfBirth: string; // YYYY-MM-DD
+    email: string;
+    phoneNumbers?: { number: string; type: number | string }[];
+  }): Promise<string> {
+    return this.post("/crm/v1/guardians", { phoneNumbers: [], ...guardian });
+  }
+
+  async deleteGuardian(id: string): Promise<void> {
+    await this.delete(`/crm/v1/guardians/${id}`);
+  }
+
+  async linkGuardianToChild(
+    childId: string,
+    guardianId: string,
+    relationshipType: number | string,
+  ): Promise<string> {
+    return this.post(`/crm/v1/children/${childId}/guardians/${guardianId}`, { relationshipType });
+  }
+
+  // --- Scheduling ---
+
+  async createGroup(name: string): Promise<string> {
+    return this.post("/scheduling/v1/groups", { name });
+  }
+
+  async deleteGroup(id: string): Promise<void> {
+    await this.delete(`/scheduling/v1/groups/${id}`);
+  }
+
+  async createTimeSlot(timeSlot: {
+    name: string;
+    startTime: string; // HH:mm:ss
+    endTime: string; // HH:mm:ss
+  }): Promise<string> {
+    return this.post("/scheduling/v1/timeslots", timeSlot);
+  }
+
+  async deleteTimeSlot(id: string): Promise<void> {
+    await this.delete(`/scheduling/v1/timeslots/${id}`);
+  }
+
+  /**
+   * Creating a schedule requires the child to exist in the Scheduling service,
+   * which receives it asynchronously from CRM over RabbitMQ — hence the retry.
+   */
+  async createSchedule(schedule: {
+    childId: string;
+    startDate: string; // YYYY-MM-DD
+    scheduleRules: { day: number; timeSlotId: string; groupId: string }[];
+  }): Promise<string> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      try {
+        return await this.post("/scheduling/v1/schedules", schedule);
+      } catch (error) {
+        lastError = error;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+    throw lastError;
+  }
+
+  async createClosurePeriod(period: {
+    startDate: string; // YYYY-MM-DD
+    endDate: string; // YYYY-MM-DD
+    reason: string;
+  }): Promise<string> {
+    return this.post("/scheduling/v1/closure-periods", period);
+  }
+
+  async deleteClosurePeriod(id: string): Promise<void> {
+    await this.delete(`/scheduling/v1/closure-periods/${id}`);
+  }
+
+  async createEndMark(endMark: {
+    childId: string;
+    endDate: string; // YYYY-MM-DD
+    reason?: string;
+  }): Promise<string> {
+    return this.post("/scheduling/v1/endmarks", endMark);
+  }
+
+  async deleteEndMark(id: string): Promise<void> {
+    await this.delete(`/scheduling/v1/endmarks/${id}`);
+  }
+
+  async addAbsence(absence: {
+    childId: string;
+    startDate: string;
+    endDate: string;
+    reason?: string;
+  }): Promise<string> {
+    return this.post(`/scheduling/v1/children/${absence.childId}/absences`, absence);
+  }
+}
+
+/** Unique, recognizable test-data name to avoid collisions between runs. */
+export function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+}

--- a/tests/e2e/helpers/app.ts
+++ b/tests/e2e/helpers/app.ts
@@ -1,0 +1,13 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Navigate to an app path, transparently riding through the mock-auth login
+ * bounce (/auth/login -> mock authorize -> /auth/callback -> destination).
+ * The mock auto-approves, so no credentials are involved.
+ */
+export async function gotoApp(page: Page, path = "/"): Promise<void> {
+  await page.goto(path);
+  await page.waitForURL((url) => !url.pathname.startsWith("/auth/"), { timeout: 30_000 });
+  // The app shell (top navbar) signals that providers and router are settled.
+  await expect(page.getByRole("banner")).toBeVisible({ timeout: 15_000 });
+}

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,0 +1,26 @@
+import { MOCK_AUTH_URL } from "./config";
+
+let cachedToken: string | null = null;
+
+/**
+ * Mint an API access token from the mock auth server (client_credentials grant).
+ * Used for seeding/cleaning test data directly against the APIs.
+ */
+export async function getApiToken(): Promise<string> {
+  if (cachedToken) return cachedToken;
+  const response = await fetch(`${MOCK_AUTH_URL}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: "e2e-seeder",
+      audience: "https://api.kdvmanager.nl/",
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to get API token from mock-auth: ${response.status}`);
+  }
+  const body = (await response.json()) as { access_token: string };
+  cachedToken = body.access_token;
+  return cachedToken;
+}

--- a/tests/e2e/helpers/config.ts
+++ b/tests/e2e/helpers/config.ts
@@ -1,0 +1,3 @@
+export const WEB_URL = process.env.E2E_WEB_URL ?? "http://localhost:9090";
+export const API_URL = process.env.E2E_API_URL ?? "http://localhost:5200";
+export const MOCK_AUTH_URL = process.env.E2E_MOCK_AUTH_URL ?? "http://localhost:5300";

--- a/tests/e2e/helpers/datefield.ts
+++ b/tests/e2e/helpers/datefield.ts
@@ -1,0 +1,17 @@
+import type { Locator } from "@playwright/test";
+
+/**
+ * Fill a MUI X (v7+ accessible DOM structure) date field.
+ *
+ * The field renders as role="group" (named after its label) containing one
+ * role="spinbutton" per date section. The app uses the dayjs adapter with
+ * adapterLocale="nl", so the section order is DD-MM-YYYY. Clicking the first
+ * section and typing the digits lets the field auto-advance between sections.
+ *
+ * @param group the role="group" locator of the date field
+ * @param date date in "DD-MM-YYYY" (separators are stripped before typing)
+ */
+export async function fillMuiDateField(group: Locator, date: string): Promise<void> {
+  await group.getByRole("spinbutton").first().click();
+  await group.page().keyboard.type(date.replace(/\D/g, ""));
+}

--- a/tests/e2e/mock-auth/server.mjs
+++ b/tests/e2e/mock-auth/server.mjs
@@ -77,6 +77,19 @@ const idToken = (clientId, nonce) =>
 // code -> { nonce, clientId }
 const issuedCodes = new Map();
 
+/** JSON-encode for safe embedding inside a <script> block (no </script> breakout). */
+const jsonForScript = (value) => JSON.stringify(value).replace(/</g, "\\u003c");
+
+/** Only redirect within the local e2e stack. */
+const isAllowedRedirect = (value) => {
+  try {
+    const target = new URL(value);
+    return ["localhost", "127.0.0.1"].includes(target.hostname);
+  } catch {
+    return false;
+  }
+};
+
 const sendJson = (res, status, body, extraHeaders = {}) => {
   res.writeHead(status, { "Content-Type": "application/json", ...extraHeaders });
   res.end(JSON.stringify(body));
@@ -148,12 +161,14 @@ const server = http.createServer(async (req, res) => {
       return res.end(`<!DOCTYPE html><html><body><script>
         parent.postMessage({
           type: "authorization_response",
-          response: { code: ${JSON.stringify(code)}, state: ${JSON.stringify(state)} }
+          response: { code: ${jsonForScript(code)}, state: ${jsonForScript(state)} }
         }, "*");
       </script></body></html>`);
     }
 
-    if (!redirectUri) return sendJson(res, 400, { error: "invalid_request" });
+    if (!redirectUri || !isAllowedRedirect(redirectUri)) {
+      return sendJson(res, 400, { error: "invalid_request" });
+    }
     const target = new URL(redirectUri);
     target.searchParams.set("code", code);
     target.searchParams.set("state", state);
@@ -212,7 +227,7 @@ const server = http.createServer(async (req, res) => {
 
   if (url.pathname === "/v2/logout" || url.pathname === "/oidc/logout") {
     const returnTo = url.searchParams.get("returnTo") ?? url.searchParams.get("post_logout_redirect_uri");
-    if (returnTo) {
+    if (returnTo && isAllowedRedirect(returnTo)) {
       res.writeHead(302, { Location: returnTo });
       return res.end();
     }

--- a/tests/e2e/mock-auth/server.mjs
+++ b/tests/e2e/mock-auth/server.mjs
@@ -228,8 +228,19 @@ const server = http.createServer(async (req, res) => {
   if (url.pathname === "/v2/logout" || url.pathname === "/oidc/logout") {
     const returnTo = url.searchParams.get("returnTo") ?? url.searchParams.get("post_logout_redirect_uri");
     if (returnTo && isAllowedRedirect(returnTo)) {
-      res.writeHead(302, { Location: returnTo });
-      return res.end();
+      try {
+        const issuerOrigin = new URL(ISSUER).origin;
+        const normalizedReturnTo = new URL(returnTo, ISSUER);
+        if (
+          (normalizedReturnTo.protocol === "http:" || normalizedReturnTo.protocol === "https:") &&
+          normalizedReturnTo.origin === issuerOrigin
+        ) {
+          res.writeHead(302, { Location: normalizedReturnTo.toString() });
+          return res.end();
+        }
+      } catch {
+        // Ignore invalid URLs and fall through to non-redirect response.
+      }
     }
     res.writeHead(200);
     return res.end("Logged out");

--- a/tests/e2e/mock-auth/server.mjs
+++ b/tests/e2e/mock-auth/server.mjs
@@ -1,0 +1,233 @@
+/**
+ * Zero-dependency mock OIDC provider for e2e tests.
+ *
+ * Stands in for Auth0 so the full stack (SPA, Envoy JWT filter, .NET APIs) can run
+ * without external dependencies or secrets. Every /authorize request is auto-approved
+ * as a fixed test user belonging to a fixed tenant.
+ *
+ * Supported flows:
+ *  - authorization_code (+PKCE params accepted, not verified) via 302 redirect
+ *  - silent auth via response_mode=web_message (auth0-spa-js iframe checkSession)
+ *  - refresh_token grant (auth0-spa-js useRefreshTokens)
+ *  - client_credentials grant (test data seeding from Playwright)
+ *  - /v2/logout and /oidc/logout redirects
+ *  - /.well-known/openid-configuration and /.well-known/jwks.json
+ *
+ * The issuer is the browser-facing URL (http://localhost:5300/) while backend
+ * containers reach this server as http://mock-auth:5300 — the discovery document
+ * derives its jwks_uri from the request Host header so both work.
+ */
+import http from "node:http";
+import crypto from "node:crypto";
+
+const PORT = Number(process.env.PORT ?? 5300);
+const ISSUER = (process.env.MOCK_AUTH_ISSUER ?? "http://localhost:5300/").replace(/\/?$/, "/");
+const TENANT_ID = process.env.E2E_TENANT_ID ?? "b1aebd35-9ab8-4f7e-9b3d-7d7f0d20a1c5";
+const API_AUDIENCE = "https://api.kdvmanager.nl/";
+const KID = "e2e-mock-key-1";
+const TOKEN_TTL_SECONDS = 86400;
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+const publicJwk = publicKey.export({ format: "jwk" });
+
+const b64url = (input) =>
+  Buffer.from(input).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+const signJwt = (payload) => {
+  const header = b64url(JSON.stringify({ alg: "RS256", typ: "JWT", kid: KID }));
+  const body = b64url(JSON.stringify(payload));
+  const signature = crypto
+    .sign("RSA-SHA256", Buffer.from(`${header}.${body}`), privateKey)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `${header}.${body}.${signature}`;
+};
+
+const now = () => Math.floor(Date.now() / 1000);
+
+const accessToken = (clientId) =>
+  signJwt({
+    iss: ISSUER,
+    sub: "auth0|e2e-test-user",
+    aud: [API_AUDIENCE, API_AUDIENCE.replace(/\/$/, "")],
+    azp: clientId,
+    iat: now(),
+    exp: now() + TOKEN_TTL_SECONDS,
+    scope: "openid profile email offline_access",
+    "https://kdvmanager.nl/tenant": TENANT_ID,
+  });
+
+const idToken = (clientId, nonce) =>
+  signJwt({
+    iss: ISSUER,
+    sub: "auth0|e2e-test-user",
+    aud: clientId,
+    iat: now(),
+    exp: now() + TOKEN_TTL_SECONDS,
+    ...(nonce ? { nonce } : {}),
+    name: "E2E Test User",
+    nickname: "e2e",
+    email: "e2e@kdvmanager.nl",
+    email_verified: true,
+    updated_at: new Date().toISOString(),
+  });
+
+// code -> { nonce, clientId }
+const issuedCodes = new Map();
+
+const sendJson = (res, status, body, extraHeaders = {}) => {
+  res.writeHead(status, { "Content-Type": "application/json", ...extraHeaders });
+  res.end(JSON.stringify(body));
+};
+
+const readBody = (req) =>
+  new Promise((resolve) => {
+    let data = "";
+    req.on("data", (chunk) => (data += chunk));
+    req.on("end", () => resolve(data));
+  });
+
+const parseBody = (raw, contentType = "") => {
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  return Object.fromEntries(new URLSearchParams(raw));
+};
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  // CORS for browser calls (token endpoint, jwks) from the SPA origin.
+  res.setHeader("Access-Control-Allow-Origin", req.headers.origin ?? "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "content-type, authorization, auth0-client");
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    return res.end();
+  }
+
+  if (url.pathname === "/.well-known/openid-configuration") {
+    const self = `http://${req.headers.host}`;
+    return sendJson(res, 200, {
+      issuer: ISSUER,
+      authorization_endpoint: `${ISSUER}authorize`,
+      token_endpoint: `${self}/oauth/token`,
+      jwks_uri: `${self}/.well-known/jwks.json`,
+      userinfo_endpoint: `${self}/userinfo`,
+      response_types_supported: ["code"],
+      subject_types_supported: ["public"],
+      id_token_signing_alg_values_supported: ["RS256"],
+    });
+  }
+
+  if (url.pathname === "/.well-known/jwks.json") {
+    return sendJson(res, 200, {
+      keys: [{ kty: "RSA", use: "sig", alg: "RS256", kid: KID, n: publicJwk.n, e: publicJwk.e }],
+    });
+  }
+
+  if (url.pathname === "/authorize") {
+    const clientId = url.searchParams.get("client_id") ?? "e2e-client";
+    const redirectUri = url.searchParams.get("redirect_uri");
+    const state = url.searchParams.get("state") ?? "";
+    const nonce = url.searchParams.get("nonce") ?? undefined;
+    const responseMode = url.searchParams.get("response_mode");
+
+    const code = crypto.randomUUID();
+    issuedCodes.set(code, { nonce, clientId });
+
+    if (responseMode === "web_message") {
+      // Silent auth: auth0-spa-js listens for a postMessage from this iframe.
+      res.writeHead(200, { "Content-Type": "text/html" });
+      return res.end(`<!DOCTYPE html><html><body><script>
+        parent.postMessage({
+          type: "authorization_response",
+          response: { code: ${JSON.stringify(code)}, state: ${JSON.stringify(state)} }
+        }, "*");
+      </script></body></html>`);
+    }
+
+    if (!redirectUri) return sendJson(res, 400, { error: "invalid_request" });
+    const target = new URL(redirectUri);
+    target.searchParams.set("code", code);
+    target.searchParams.set("state", state);
+    res.writeHead(302, { Location: target.toString() });
+    return res.end();
+  }
+
+  if (url.pathname === "/oauth/token" && req.method === "POST") {
+    const body = parseBody(await readBody(req), req.headers["content-type"]);
+    const grantType = body.grant_type;
+    const clientId = body.client_id ?? "e2e-client";
+
+    if (grantType === "authorization_code") {
+      const stored = issuedCodes.get(body.code);
+      issuedCodes.delete(body.code);
+      if (!stored) return sendJson(res, 403, { error: "invalid_grant" });
+      return sendJson(res, 200, {
+        access_token: accessToken(stored.clientId),
+        id_token: idToken(stored.clientId, stored.nonce),
+        refresh_token: crypto.randomUUID(),
+        token_type: "Bearer",
+        expires_in: TOKEN_TTL_SECONDS,
+        scope: "openid profile email offline_access",
+      });
+    }
+
+    if (grantType === "refresh_token") {
+      return sendJson(res, 200, {
+        access_token: accessToken(clientId),
+        id_token: idToken(clientId),
+        refresh_token: crypto.randomUUID(),
+        token_type: "Bearer",
+        expires_in: TOKEN_TTL_SECONDS,
+        scope: "openid profile email offline_access",
+      });
+    }
+
+    if (grantType === "client_credentials") {
+      return sendJson(res, 200, {
+        access_token: accessToken(clientId),
+        token_type: "Bearer",
+        expires_in: TOKEN_TTL_SECONDS,
+      });
+    }
+
+    return sendJson(res, 400, { error: "unsupported_grant_type" });
+  }
+
+  if (url.pathname === "/userinfo") {
+    return sendJson(res, 200, {
+      sub: "auth0|e2e-test-user",
+      name: "E2E Test User",
+      email: "e2e@kdvmanager.nl",
+    });
+  }
+
+  if (url.pathname === "/v2/logout" || url.pathname === "/oidc/logout") {
+    const returnTo = url.searchParams.get("returnTo") ?? url.searchParams.get("post_logout_redirect_uri");
+    if (returnTo) {
+      res.writeHead(302, { Location: returnTo });
+      return res.end();
+    }
+    res.writeHead(200);
+    return res.end("Logged out");
+  }
+
+  if (url.pathname === "/healthz") {
+    res.writeHead(200);
+    return res.end("ok");
+  }
+
+  sendJson(res, 404, { error: "not_found", path: url.pathname });
+});
+
+server.listen(PORT, () => {
+  console.log(`mock-auth listening on :${PORT} (issuer ${ISSUER}, tenant ${TENANT_ID})`);
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kdvmanager-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.57.0",
+    "@types/node": "^24.10.1",
+    "typescript": "^5.9.3"
+  },
+  "packageManager": "pnpm@11.0.8"
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const WEB_URL = process.env.E2E_WEB_URL ?? "http://localhost:9090";
+
+export default defineConfig({
+  testDir: "./specs",
+  globalSetup: "./global-setup.ts",
+  // Tests share one tenant/database, so run serially for deterministic list contents.
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  forbidOnly: !!process.env.CI,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [["list"], ["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: WEB_URL,
+    locale: "nl-NL",
+    timezoneId: "Europe/Amsterdam",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/e2e/pnpm-lock.yaml
+++ b/tests/e2e/pnpm-lock.yaml
@@ -1,0 +1,77 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.60.0
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.13.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+snapshots:
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}

--- a/tests/e2e/specs/auth.spec.ts
+++ b/tests/e2e/specs/auth.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Use cases covered (task 1 — auth flow):
+ *  UC1.1 Unauthenticated visit to "/" rides the login bounce and lands on /schedule.
+ *  UC1.2 A deep link (/children) is preserved through the login bounce.
+ *  UC1.3 Logging out via the account menu redirects to the (mock) Auth0 logout endpoint.
+ *
+ * Notes on the flow (see src/web/src/lib/auth/auth.ts and pages/auth/*):
+ *  - Protected routes redirect to /auth/login?returnTo=<path>, which bounces through the
+ *    auto-approving mock IdP and /auth/callback back to the original destination.
+ *  - AccountMenu calls auth0-react logout() without returnTo, so the browser ends up on
+ *    the mock IdP's /v2/logout page, which renders the plain text "Logged out"
+ *    (tests/e2e/mock-auth/server.mjs).
+ */
+import { test, expect } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+
+test.describe("authentication", () => {
+  test("unauthenticated visit goes through login flow and lands on the schedule page", async ({
+    page,
+  }) => {
+    // Raw navigation on purpose: we want to observe the auth bounce ourselves.
+    await page.goto("/");
+
+    // "/" redirects to /schedule, which bounces through /auth/login -> mock -> /auth/callback.
+    await page.waitForURL((url) => url.pathname === "/schedule", { timeout: 30_000 });
+
+    await expect(page).toHaveURL(/\/schedule/);
+    // Main UI is visible: app navbar and the schedule overview page title ("Planningsoverzicht").
+    await expect(page.getByRole("banner")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Planningsoverzicht" })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("deep link is preserved through the login bounce", async ({ page }) => {
+    await page.goto("/children");
+
+    // The returnTo query param carries /children through the bounce (LoginPage/CallbackPage).
+    await page.waitForURL((url) => url.pathname === "/children", { timeout: 30_000 });
+
+    await expect(page).toHaveURL(/\/children/);
+    await expect(page.getByRole("banner")).toBeVisible();
+  });
+
+  test("user can log out", async ({ page }) => {
+    await gotoApp(page, "/schedule");
+
+    // The account menu trigger is the avatar IconButton in the navbar (AccountMenu.tsx).
+    // It has no stable accessible name (avatar fallback letter), so locate it as the
+    // only visible navbar button containing an avatar.
+    const accountButton = page
+      .getByRole("banner")
+      .locator("button")
+      .filter({ has: page.locator(".MuiAvatar-root") });
+    await accountButton.click();
+
+    await page.getByRole("menuitem", { name: "Uitloggen" }).click();
+
+    // auth0-react logout() without returnTo: we end up on the mock IdP logout endpoint,
+    // which responds with the plain text "Logged out".
+    await page.waitForURL(/\/v2\/logout/, { timeout: 30_000 });
+    await expect(page.getByText("Logged out")).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/child-planning.spec.ts
+++ b/tests/e2e/specs/child-planning.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Child planning tab (schedules + end marks) — e2e specs.
+ *
+ * Use cases covered:
+ * - The planning tab renders a schedule and an end mark seeded via the API
+ *   (schedule card with period/time-slot/group, end-mark card with date/reason).
+ * - Adding a schedule through the "Planning toevoegen" dialog (start date,
+ *   rule with day + time slot + group) and seeing it appear in the tab.
+ * - Adding an end mark through the inline "Eindmarkering toevoegen" form.
+ * - Deleting a schedule via the schedule card action + confirmation dialog.
+ *
+ * The schedule overview page itself is covered by schedule-overview.spec.ts,
+ * so this file stays focused on the child planning tab UI.
+ *
+ * All Dutch strings are taken from src/web/src/locales/nl/{translation,common}.json.
+ * Note: the weekday buttons in the add-schedule dialog show untranslated short
+ * names ("Mon", "Tue", ...) on desktop — see AddChildScheduleDialog_v2.tsx.
+ *
+ * Every child also gets a system-generated end mark ("Eindmarkering" + "Auto"
+ * chips) as soon as the Scheduling service learns about it (see
+ * EndMarkAutomationService.cs). Consequences for these tests:
+ * - the timeline is never empty, so the "Geen planningen gevonden" empty state
+ *   never renders for our children;
+ * - "Eindmarkering" chip assertions must be scoped to the card with our unique
+ *   reason text, otherwise they hit the auto card too (strict mode violation).
+ */
+import { test, expect } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+import { fillMuiDateField } from "../helpers/datefield";
+
+// A Monday in the past so seeded/created schedules are immediately active.
+const SCHEDULE_START = "2026-01-05"; // YYYY-MM-DD (API)
+const SCHEDULE_START_NL = "05-01-2026"; // DD-MM-YYYY (MUI date field, nl locale)
+
+test.describe("child planning tab", () => {
+  let api: Api;
+  let groupId: string;
+  let timeSlotId: string;
+  let childAId: string; // gets a seeded schedule + end mark
+  let childBId: string; // used for UI-driven creation
+  const groupName = uniqueName("Groep");
+  const timeSlotName = uniqueName("Blok");
+  const familyA = uniqueName("PlanA");
+  const familyB = uniqueName("PlanB");
+  const endMarkReason = uniqueName("Reden");
+
+  test.beforeAll(async () => {
+    api = await Api.create();
+    groupId = await api.createGroup(groupName);
+    timeSlotId = await api.createTimeSlot({
+      name: timeSlotName,
+      startTime: "08:30:00",
+      endTime: "13:00:00",
+    });
+    childAId = await api.createChild({ givenName: "Mila", familyName: familyA, dateOfBirth: "2023-03-10" });
+    childBId = await api.createChild({ givenName: "Lars", familyName: familyB, dateOfBirth: "2023-04-20" });
+
+    // The Scheduling service learns about new children asynchronously from CRM
+    // (RabbitMQ). api.createSchedule retries internally until replication has
+    // settled, so after these calls both children are known to Scheduling.
+    // Child A keeps its schedule (rendered + deleted in the tests below).
+    await api.createSchedule({
+      childId: childAId,
+      startDate: SCHEDULE_START,
+      scheduleRules: [{ day: 1 /* Monday */, timeSlotId, groupId }],
+    });
+    await api.createEndMark({ childId: childAId, endDate: "2030-06-30", reason: endMarkReason });
+
+    // Child B gets a throwaway schedule purely to wait out replication, so the
+    // UI-driven submit in "add a schedule via the dialog" cannot race it.
+    const dummyScheduleId = await api.createSchedule({
+      childId: childBId,
+      startDate: SCHEDULE_START,
+      scheduleRules: [{ day: 2 /* Tuesday */, timeSlotId, groupId }],
+    });
+    await api.delete(`/scheduling/v1/schedules/${dummyScheduleId}`);
+  });
+
+  test.afterAll(async () => {
+    const attempt = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn();
+      } catch {
+        // Best-effort cleanup — ignore failures (e.g. already deleted).
+      }
+    };
+
+    for (const childId of [childAId, childBId]) {
+      if (!childId) continue;
+      // Schedules and end marks first (dependency order), then the child.
+      await attempt(async () => {
+        const schedules = await api.get<{ id?: string }[]>(
+          `/scheduling/v1/schedules?childId=${childId}`,
+        );
+        for (const schedule of schedules) {
+          if (schedule.id) await attempt(() => api.delete(`/scheduling/v1/schedules/${schedule.id}`));
+        }
+      });
+      await attempt(async () => {
+        const endMarks = await api.get<{ id?: string }[]>(
+          `/scheduling/v1/endmarks?childId=${childId}`,
+        );
+        for (const endMark of endMarks) {
+          if (endMark.id) await attempt(() => api.deleteEndMark(endMark.id!));
+        }
+      });
+      await attempt(() => api.deleteChild(childId));
+    }
+    if (timeSlotId) await attempt(() => api.deleteTimeSlot(timeSlotId));
+    if (groupId) await attempt(() => api.deleteGroup(groupId));
+    await api.dispose();
+  });
+
+  test("planning tab shows a seeded schedule and end mark", async ({ page }) => {
+    await gotoApp(page, `/children/${childAId}/planning`);
+
+    await expect(page.getByRole("heading", { name: "Huidige planning" })).toBeVisible();
+
+    // Schedule card: period title, time-slot chip (HH:mm-HH:mm) and group name.
+    await expect(page.getByText("Planningsperiode")).toBeVisible();
+    await expect(page.getByText("08:30-13:00")).toBeVisible();
+    await expect(page.getByText(groupName)).toBeVisible();
+
+    // End-mark card: chip, date (rendered as YYYY-MM-DD) and reason. Scoped to
+    // the seeded card because the auto-generated end mark renders the same chip.
+    const endMarkCard = page.locator(".MuiCard-root").filter({ hasText: endMarkReason });
+    await expect(endMarkCard.getByText("Eindmarkering", { exact: true })).toBeVisible();
+    await expect(endMarkCard.getByText("2030-06-30")).toBeVisible();
+  });
+
+  test("add a schedule via the dialog", async ({ page }) => {
+    await gotoApp(page, `/children/${childBId}/planning`);
+
+    // The auto-generated end mark means the timeline is never empty, so assert
+    // the precondition as "no schedule card yet" instead of the empty state.
+    await expect(page.getByRole("heading", { name: "Huidige planning" })).toBeVisible();
+    await expect(page.getByText("Planningsperiode")).toHaveCount(0);
+    await page.getByRole("button", { name: "Planning toevoegen" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    await fillMuiDateField(dialog.getByRole("group", { name: /Startdatum/ }), SCHEDULE_START_NL);
+
+    // Add a rule; the new rule opens in edit mode with day / time slot / group
+    // selectors (desktop weekday buttons show short English names).
+    await dialog.getByRole("button", { name: "Regel toevoegen" }).click();
+    await dialog.getByRole("button").filter({ hasText: /Mon/ }).click();
+    await dialog.getByRole("button").filter({ hasText: timeSlotName }).click();
+    await dialog.getByRole("button").filter({ hasText: groupName }).click();
+    await dialog.getByRole("button", { name: "Gereed" }).click();
+
+    // Submit label reads "Planning aanmaken (1/1)".
+    await dialog.getByRole("button", { name: /Planning aanmaken/ }).click();
+
+    await expect(page.getByText("Planning succesvol toegevoegd")).toBeVisible();
+    await expect(dialog).not.toBeVisible();
+
+    // The new schedule renders in the timeline.
+    await expect(page.getByText("Planningsperiode")).toBeVisible();
+    await expect(page.getByText("08:30-13:00")).toBeVisible();
+    await expect(page.getByText(groupName)).toBeVisible();
+  });
+
+  test("add an end mark via the inline form", async ({ page }) => {
+    await gotoApp(page, `/children/${childBId}/planning`);
+
+    // Toggle the inline form open (the toggle then reads "Annuleren", so the
+    // submit button below is the only "Eindmarkering toevoegen" left).
+    await page.getByRole("button", { name: "Eindmarkering toevoegen" }).click();
+
+    // Native <input type="date"> — fill takes the ISO value.
+    await page.getByLabel("Einddatum").fill("2031-01-15");
+    await page.getByLabel("Reden").fill(`${endMarkReason}-ui`);
+    await page.getByRole("button", { name: "Eindmarkering toevoegen" }).click();
+
+    // Scope to the new card — the auto-generated end mark shows the same chip.
+    const newEndMarkCard = page
+      .locator(".MuiCard-root")
+      .filter({ hasText: `${endMarkReason}-ui` });
+    await expect(newEndMarkCard.getByText("Eindmarkering", { exact: true })).toBeVisible();
+    await expect(newEndMarkCard.getByText("2031-01-15")).toBeVisible();
+  });
+
+  test("delete a schedule via the card action", async ({ page }) => {
+    await gotoApp(page, `/children/${childAId}/planning`);
+
+    await expect(page.getByText("Planningsperiode")).toBeVisible();
+    await page.getByRole("button", { name: "Verwijder Planning" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toContainText("Verwijder Planning");
+    await dialog.getByRole("button", { name: "Verwijderen", exact: true }).click();
+
+    await expect(page.getByText("Planning is succesvol verwijderd")).toBeVisible();
+    await expect(page.getByText("Planningsperiode")).not.toBeVisible();
+    // The seeded end mark is untouched and remains on the timeline (scoped to
+    // its card — the auto-generated end mark shows the same chip).
+    await expect(
+      page
+        .locator(".MuiCard-root")
+        .filter({ hasText: endMarkReason })
+        .getByText("Eindmarkering", { exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/children.spec.ts
+++ b/tests/e2e/specs/children.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Children management (CRM) — e2e specs.
+ *
+ * Use cases covered:
+ * - Children list shows children seeded through the API (MUI DataGrid rows).
+ * - The search field filters the list (300ms debounce, server-side search).
+ * - Creating a new child via the form (incl. MUI date field) redirects to the
+ *   child detail page and shows the child's name.
+ * - Editing child details on the detail page (Basic Information card edit
+ *   toggle -> change family name -> save -> persisted after reload).
+ * - Deleting a child from the list via the row action + confirmation dialog.
+ * - The pagination control is present on the list (interacting with paging
+ *   would require seeding >10 rows, which is intentionally skipped).
+ *
+ * All Dutch strings are taken from src/web/src/locales/nl/{translation,common}.json.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+import { fillMuiDateField } from "../helpers/datefield";
+
+const DOB = "2022-02-01"; // arbitrary, stable date of birth for seeded children
+
+test.describe("children", () => {
+  let api: Api;
+  /** Every child created in this file (seeded or via UI) is cleaned up here. */
+  const createdChildIds: string[] = [];
+
+  test.beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  test.afterAll(async () => {
+    for (const id of createdChildIds) {
+      try {
+        await api.deleteChild(id);
+      } catch {
+        // Already deleted by a test (or never fully created) — ignore.
+      }
+    }
+    await api.dispose();
+  });
+
+  async function seedChild(givenName: string, familyName: string): Promise<string> {
+    const id = await api.createChild({ givenName, familyName, dateOfBirth: DOB });
+    createdChildIds.push(id);
+    return id;
+  }
+
+  /** DataGrid row containing the given (unique) texts. */
+  function row(page: Page, ...texts: string[]) {
+    let rows = page.getByRole("row");
+    for (const text of texts) {
+      rows = rows.filter({ hasText: text });
+    }
+    return rows;
+  }
+
+  test("children list shows seeded children", async ({ page }) => {
+    // Both children share one unique family name. The tenant database is
+    // shared across runs, so the unscoped first page (size 10) may not contain
+    // fresh rows; scoping the list via the supported ?q= URL param keeps the
+    // assertion deterministic while still rendering the regular list page.
+    const familyName = uniqueName("Lijst");
+    await seedChild("Anna", familyName);
+    await seedChild("Bram", familyName);
+
+    await gotoApp(page, `/children?q=${familyName}`);
+
+    await expect(row(page, "Anna", familyName)).toBeVisible();
+    await expect(row(page, "Bram", familyName)).toBeVisible();
+  });
+
+  test("search filters the list", async ({ page }) => {
+    const familyA = uniqueName("ZoekA");
+    const familyB = uniqueName("ZoekB");
+    await seedChild("Saar", familyA);
+    await seedChild("Tess", familyB);
+
+    await gotoApp(page, "/children");
+
+    // The search input debounces 300ms before updating ?q=; the web-first
+    // assertions below retry until the filtered result is rendered.
+    await page.getByPlaceholder("Zoek kinderen…").fill(familyA);
+
+    await expect(row(page, "Saar", familyA)).toBeVisible();
+    await expect(row(page, "Tess", familyB)).not.toBeVisible();
+  });
+
+  test("create a new child via the form", async ({ page }) => {
+    const givenName = "Noor";
+    const familyName = uniqueName("Nieuw");
+
+    await gotoApp(page, "/children");
+    await page.getByRole("link", { name: "Kind toevoegen" }).click();
+
+    await page.getByLabel("Voornaam").fill(givenName);
+    await page.getByLabel("Achternaam").fill(familyName);
+    await fillMuiDateField(page.getByRole("group", { name: /Geboortedatum/ }), "01-02-2022");
+
+    await page.getByRole("button", { name: "Opslaan" }).click();
+
+    // Successful creation navigates to /children/<guid>.
+    await page.waitForURL(/\/children\/[0-9a-f]{8}-[0-9a-f-]{27}$/i);
+    const childId = new URL(page.url()).pathname.split("/").pop()!;
+    createdChildIds.push(childId);
+
+    await expect(
+      page.getByRole("heading", { name: `${givenName} ${familyName}` }),
+    ).toBeVisible();
+  });
+
+  test("edit child details", async ({ page }) => {
+    const childId = await seedChild("Evi", uniqueName("Voor"));
+    const newFamilyName = uniqueName("Bewerkt");
+
+    await gotoApp(page, `/children/${childId}`);
+
+    // The Basic Information card is read-only until its edit toggle (an icon
+    // button without aria-label in the card header) is clicked.
+    const basicCard = page.locator(".MuiCard-root").filter({ hasText: "Basisinformatie" });
+    await basicCard.getByRole("button").first().click();
+
+    await basicCard.getByLabel("Achternaam").fill(newFamilyName);
+
+    // In edit mode the first header button is Save (second is Cancel).
+    await basicCard.getByRole("button").first().click();
+    await expect(page.getByText("Basisinformatie succesvol bijgewerkt")).toBeVisible();
+
+    // Re-navigate and verify the change persisted.
+    await gotoApp(page, `/children/${childId}`);
+    await expect(page.getByRole("heading", { name: `Evi ${newFamilyName}` })).toBeVisible();
+  });
+
+  test("delete a child from the list", async ({ page }) => {
+    const familyName = uniqueName("Weg");
+    await seedChild("Wout", familyName);
+
+    await gotoApp(page, `/children?q=${familyName}`);
+    const childRow = row(page, "Wout", familyName);
+    await expect(childRow).toBeVisible();
+
+    await childRow.getByRole("button", { name: "Verwijder kind" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toContainText(familyName);
+    await dialog.getByRole("button", { name: "Verwijderen", exact: true }).click();
+
+    await expect(childRow).not.toBeVisible();
+  });
+
+  test("pagination control is present", async ({ page }) => {
+    await gotoApp(page, "/children");
+
+    // Interacting with paging reliably would need >10 seeded rows, which is
+    // expensive; assert the DataGrid pagination control renders instead.
+    await expect(page.locator(".MuiTablePagination-root")).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/guardians.spec.ts
+++ b/tests/e2e/specs/guardians.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * E2E specs for guardian management (CRM).
+ *
+ * Covered use cases:
+ * 1. Guardians list shows seeded guardians; searching by a unique family name
+ *    filters the DataGrid (debounced search field + filter chip).
+ * 2. Create a guardian via the "Nieuwe voogd toevoegen" form. NOTE: the form
+ *    navigates back to the guardians LIST after saving (see GuardianForm
+ *    handleFormSubmit), so the new guardian is verified through the list.
+ * 3. Edit guardian basic details on the detail page via the edit-in-place
+ *    "Basisinformatie" card, then verify persistence after a reload.
+ * 4. Link a child to a guardian. NOTE: link UI was removed from the guardian
+ *    detail page (see GuardianDetailPage / GuardianChildrenCard), so linking is
+ *    done from the CHILD detail page ("Voogd koppelen" dialog) and the result is
+ *    verified in the guardian's linked-children card.
+ * 5. Unlink a child on the guardian detail page (unlink icon + confirm dialog).
+ * 6. Delete a guardian from the list page row action with confirmation dialog.
+ *
+ * All data is seeded with uniqueName() and cleaned up in afterAll (try/catch
+ * per entity), so this file is independent of other specs.
+ */
+
+import { test, expect, type Page, type Locator } from "@playwright/test";
+import { Api, uniqueName } from "../helpers/api";
+import { gotoApp } from "../helpers/app";
+
+type GuardianListItem = { id: string; fullName: string };
+
+type SeededGuardian = {
+  id: string;
+  givenName: string;
+  familyName: string;
+  fullName: string;
+};
+
+let api: Api;
+
+const guardianIds: string[] = [];
+const childIds: string[] = [];
+const links: { childId: string; guardianId: string }[] = [];
+// Family names of guardians created through the UI; resolved to ids in afterAll.
+const uiCreatedGuardianFamilyNames: string[] = [];
+
+test.beforeAll(async () => {
+  api = await Api.create();
+});
+
+test.afterAll(async () => {
+  // Resolve guardians created via the UI to ids so they can be deleted too.
+  for (const familyName of uiCreatedGuardianFamilyNames) {
+    try {
+      const found = await api.get<GuardianListItem[]>(
+        `/crm/v1/guardians?pageNumber=1&pageSize=20&search=${encodeURIComponent(familyName)}`,
+      );
+      guardianIds.push(...found.map((guardian) => guardian.id));
+    } catch {
+      // Ignore lookup failures during cleanup.
+    }
+  }
+  // Remove child-guardian links first; guardians with relationships cannot be deleted.
+  for (const link of links) {
+    try {
+      await api.delete(`/crm/v1/children/${link.childId}/guardians/${link.guardianId}`);
+    } catch {
+      // Already unlinked (e.g. by the unlink test) or never linked.
+    }
+  }
+  for (const id of childIds) {
+    try {
+      await api.deleteChild(id);
+    } catch {
+      // Already deleted.
+    }
+  }
+  for (const id of guardianIds) {
+    try {
+      await api.deleteGuardian(id);
+    } catch {
+      // Already deleted (e.g. by the delete test).
+    }
+  }
+  await api.dispose();
+});
+
+/**
+ * Seed a guardian via the API. Given names get an "Aaa" prefix so the seeded
+ * guardians sort to the first DataGrid page (the list is ordered by given name).
+ */
+async function seedGuardian(): Promise<SeededGuardian> {
+  const givenName = uniqueName("Aaa");
+  const familyName = uniqueName("Testvoogd");
+  const id = await api.createGuardian({
+    givenName,
+    familyName,
+    dateOfBirth: "1985-04-12",
+    email: `${uniqueName("voogd")}@example.com`,
+  });
+  guardianIds.push(id);
+  return { id, givenName, familyName, fullName: `${givenName} ${familyName}` };
+}
+
+async function seedChild(): Promise<{ id: string; fullName: string }> {
+  const givenName = uniqueName("Kind");
+  const familyName = uniqueName("Kindfam");
+  const id = await api.createChild({ givenName, familyName, dateOfBirth: "2022-05-10" });
+  childIds.push(id);
+  return { id, fullName: `${givenName} ${familyName}` };
+}
+
+/** DataGrid row containing the given text (header row never matches a full name). */
+const gridRow = (page: Page, text: string): Locator =>
+  page.getByRole("row").filter({ hasText: text });
+
+/** Guardians list search field (placeholder "Zoek voogden…", matched as substring). */
+const searchField = (page: Page): Locator => page.getByPlaceholder("Zoek voogden");
+
+/** MUI card on a detail page, identified by its title text. */
+const cardByTitle = (page: Page, title: string): Locator =>
+  page.locator(".MuiCard-root").filter({ hasText: title });
+
+test("guardians list shows seeded guardians + search", async ({ page }) => {
+  const guardianA = await seedGuardian();
+  const guardianB = await seedGuardian();
+
+  await gotoApp(page, "/guardians");
+  await expect(page.getByRole("heading", { name: "Voogden" })).toBeVisible();
+
+  // Both seeded guardians are on the first page ("Aaa…" given names sort first).
+  await expect(gridRow(page, guardianA.fullName)).toBeVisible();
+  await expect(gridRow(page, guardianB.fullName)).toBeVisible();
+
+  // Search by guardian A's unique family name (input is debounced 300ms).
+  await searchField(page).fill(guardianA.familyName);
+  await expect(page.getByText(`Filter: ${guardianA.familyName}`)).toBeVisible();
+  await expect(gridRow(page, guardianA.fullName)).toBeVisible();
+  await expect(gridRow(page, guardianB.fullName)).toHaveCount(0);
+});
+
+test("create a guardian via the form", async ({ page }) => {
+  const givenName = uniqueName("Aaa");
+  const familyName = uniqueName("Nieuwvoogd");
+  // Track for cleanup before anything can fail.
+  uiCreatedGuardianFamilyNames.push(familyName);
+
+  await gotoApp(page, "/guardians");
+  await page.getByRole("link", { name: "Voogd toevoegen" }).click();
+  await expect(page).toHaveURL(/\/guardians\/new$/);
+  await expect(page.getByRole("heading", { name: "Nieuwe voogd toevoegen" })).toBeVisible();
+
+  // "Given name"/"Family name" have no Dutch translation entry, so the literal
+  // keys are rendered as labels (required fields). Date of birth and phone
+  // numbers are optional and left empty.
+  await page.getByLabel("Given name").fill(givenName);
+  await page.getByLabel("Family name").fill(familyName);
+  // Email is optional but pattern-validated; fill a valid one.
+  await page.getByLabel("E-mail").fill(`${uniqueName("mail")}@example.com`);
+
+  await page.getByRole("button", { name: "Voogd aanmaken" }).click();
+
+  // The form navigates back to the guardians list after a successful save.
+  await expect(page).toHaveURL(/\/guardians(\?.*)?$/);
+  await searchField(page).fill(familyName);
+  await expect(gridRow(page, `${givenName} ${familyName}`)).toBeVisible();
+});
+
+test("edit guardian details", async ({ page }) => {
+  const guardian = await seedGuardian();
+  const newGivenName = uniqueName("Aab");
+
+  await gotoApp(page, `/guardians/${guardian.id}`);
+  await expect(page.getByRole("heading", { name: guardian.fullName })).toBeVisible();
+
+  // Enter edit mode on the "Basisinformatie" card. The toggle is an icon-only
+  // button without aria-label or tooltip (MUI strips icon data-testids in
+  // production builds), but it is the card's ONLY button in view mode.
+  const basicCard = cardByTitle(page, "Basisinformatie");
+  await basicCard.getByRole("button").click();
+
+  await basicCard.getByLabel("Voornaam").fill(newGivenName);
+  // In edit mode the card header renders Save then Cancel (icon-only, both
+  // unlabeled); the date picker's "choose date" button follows in the content.
+  // Save is therefore the first button in DOM order.
+  await basicCard.getByRole("button").first().click();
+
+  // Success snackbar confirms the update went through.
+  await expect(page.getByText("Basisinformatie succesvol bijgewerkt")).toBeVisible();
+
+  // Verify persistence with a hard reload.
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: `${newGivenName} ${guardian.familyName}` }),
+  ).toBeVisible();
+});
+
+test("link a child to a guardian", async ({ page }) => {
+  const guardian = await seedGuardian();
+  const child = await seedChild();
+  // Track the (future) link for cleanup before driving the UI.
+  links.push({ childId: child.id, guardianId: guardian.id });
+
+  // Linking lives on the child detail page; the guardian detail page only
+  // displays linked children.
+  await gotoApp(page, `/children/${child.id}`);
+  await page.getByRole("button", { name: "Voogd koppelen" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Bestaande voogd koppelen")).toBeVisible();
+
+  // Search (minimum 2 characters) and select the guardian from the results.
+  await dialog.getByPlaceholder("Zoek op naam...").fill(guardian.familyName);
+  await dialog.getByText(guardian.fullName).click();
+  await expect(dialog.getByText("Geselecteerd:")).toBeVisible();
+
+  // Pick the relationship type; options are the untranslated enum keys
+  // (Parent / Guardian / Grandparent / Other). "exact" avoids matching
+  // "Grandparent" by substring.
+  await dialog.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Guardian", exact: true }).click();
+
+  await dialog.getByRole("button", { name: "Voogd koppelen" }).click();
+  await expect(dialog).toBeHidden();
+
+  // The guardian appears in the child's guardian list with the translated
+  // relationship chip ("Guardian" -> "Verzorger").
+  await expect(page.getByText(guardian.fullName)).toBeVisible();
+  await expect(page.getByText("Verzorger")).toBeVisible();
+
+  // And the child appears in the guardian's linked-children card.
+  await gotoApp(page, `/guardians/${guardian.id}`);
+  await expect(cardByTitle(page, "Kinderen").getByText(child.fullName)).toBeVisible();
+});
+
+test("unlink child from guardian", async ({ page }) => {
+  const guardian = await seedGuardian();
+  const child = await seedChild();
+  await api.linkGuardianToChild(child.id, guardian.id, "Parent");
+  links.push({ childId: child.id, guardianId: guardian.id });
+
+  await gotoApp(page, `/guardians/${guardian.id}`);
+  await expect(page.getByText(child.fullName)).toBeVisible();
+
+  // Unlink icon button has aria-label "Ontkoppelen" (common.unlink); exact match
+  // avoids the clickable row wrapper, whose accessible name also contains it.
+  await page.getByRole("button", { name: "Ontkoppelen", exact: true }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Kind ontkoppelen")).toBeVisible();
+  await dialog.getByRole("button", { name: "Ontkoppelen", exact: true }).click();
+
+  // Wait for the dialog to close first: its confirmation text also contains the
+  // child's full name, which would otherwise trip strict mode (two matches).
+  await expect(dialog).toBeHidden();
+  await expect(cardByTitle(page, "Kinderen").getByText(child.fullName)).toBeHidden();
+  await expect(page.getByText("Geen kinderen gekoppeld aan deze voogd")).toBeVisible();
+});
+
+test("delete a guardian", async ({ page }) => {
+  const guardian = await seedGuardian();
+
+  await gotoApp(page, "/guardians");
+  await searchField(page).fill(guardian.familyName);
+  // The filter chip confirms the search made it into the URL (?q=...).
+  await expect(page.getByText(`Filter: ${guardian.familyName}`)).toBeVisible();
+
+  const row = gridRow(page, guardian.fullName);
+  await expect(row).toBeVisible();
+
+  // Row delete action is an icon-only button; its Tooltip ("Verwijder voogd")
+  // doubles as the accessible name. (Icon data-testids such as DeleteIcon are
+  // stripped from MUI production builds, so they cannot be used here.)
+  await row.getByRole("button", { name: "Verwijder voogd" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Verwijder voogd")).toBeVisible();
+  // Exact match: "Verwijderen" (confirm), not "Annuleren" / "Verwijderen...".
+  await dialog.getByRole("button", { name: "Verwijderen", exact: true }).click();
+  await expect(dialog.getByText("is succesvol verwijderd")).toBeVisible();
+
+  // The grid's react-query cache is invalidated with a non-matching key, so
+  // reload instead (the search term is preserved in the URL) and assert the
+  // row is gone.
+  await page.reload();
+  await expect(searchField(page)).toHaveValue(guardian.familyName);
+  await expect(gridRow(page, guardian.fullName)).toHaveCount(0);
+});

--- a/tests/e2e/specs/reports.spec.ts
+++ b/tests/e2e/specs/reports.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Use cases covered (task 3 — reporting pages):
+ *  UC3.1 Newsletter (/newsletter): generating recipients for the current month lists the
+ *        email address of a guardian linked to an active child.
+ *  UC3.2 Print schedules (/print-schedules): the filter form renders (month/year/groups
+ *        selects) and generating renders the in-page printable pages for the seeded
+ *        group, enabling the "Afdrukken" trigger (rendering is in-page, no download).
+ *  UC3.3 Print phone list (/print-phone-list): generating renders the phone list table
+ *        with the seeded child, guardian and formatted phone number.
+ *
+ * "Active child" (CRM GetActiveChildrenInPeriodAsync) is driven by activity intervals
+ * that CRM receives asynchronously from the Scheduling service after a schedule is
+ * created, so beforeAll polls the newsletter-recipients endpoint until the seeded
+ * guardian shows up before any UI assertions run.
+ */
+import { test, expect } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+
+/** Format a Date as local YYYY-MM-DD. */
+function isoDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+type NewsletterRecipientsResponse = {
+  totalActiveChildren: number;
+  recipients: { guardianId: string; fullName: string; email: string }[];
+};
+
+const groupName = uniqueName("Groep");
+const childGivenName = uniqueName("Kind");
+const childFamilyName = "Rapport";
+const childFullName = `${childGivenName} ${childFamilyName}`;
+const guardianGivenName = uniqueName("Voogd");
+const guardianFamilyName = "Rapport";
+const guardianFullName = `${guardianGivenName} ${guardianFamilyName}`;
+const guardianEmail = `${uniqueName("voogd")}@example.com`;
+// "+31612345678" renders as "06-1234 5678" (PrintPhoneListPage formatPhoneNumber).
+const guardianPhone = "+31612345678";
+const guardianPhoneFormatted = "06-1234 5678";
+
+let api: Api;
+let groupId: string;
+let timeSlotId: string;
+let childId: string;
+let guardianId: string;
+let scheduleId: string;
+
+test.beforeAll(async () => {
+  test.setTimeout(120_000); // seeding waits for cross-service replication
+
+  api = await Api.create();
+
+  groupId = await api.createGroup(groupName);
+  timeSlotId = await api.createTimeSlot({
+    name: uniqueName("Middag"),
+    startTime: "13:00:00",
+    endTime: "18:00:00",
+  });
+
+  const dob = new Date();
+  dob.setFullYear(dob.getFullYear() - 2);
+  childId = await api.createChild({
+    givenName: childGivenName,
+    familyName: childFamilyName,
+    dateOfBirth: isoDate(dob),
+  });
+
+  guardianId = await api.createGuardian({
+    givenName: guardianGivenName,
+    familyName: guardianFamilyName,
+    dateOfBirth: "1985-05-15",
+    email: guardianEmail,
+    // PhoneNumberType is a string enum in CRM: Mobile | Home | Work | Other.
+    phoneNumbers: [{ number: guardianPhone, type: "Mobile" }],
+  });
+
+  // GuardianRelationshipType is a string enum: Parent | Guardian | Grandparent | Other.
+  await api.linkGuardianToChild(childId, guardianId, "Parent");
+
+  // Past start date + rules on every weekday => the child is active in the current
+  // month/year, which is what the newsletter and phone-list queries filter on.
+  scheduleId = await api.createSchedule({
+    childId,
+    startDate: "2024-01-01",
+    scheduleRules: [1, 2, 3, 4, 5].map((day) => ({ day, timeSlotId, groupId })),
+  });
+
+  // The child's activity interval reaches CRM asynchronously (RabbitMQ); wait until
+  // the newsletter endpoint reports our guardian before running the UI tests.
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    const response = await api.get<NewsletterRecipientsResponse>(
+      `/crm/v1/children/newsletter-recipients?year=${year}&month=${month}`,
+    );
+    if (response.recipients.some((r) => r.email === guardianEmail)) break;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Seeded guardian ${guardianEmail} did not appear in newsletter recipients within 60s ` +
+          `(child activity interval replication from Scheduling to CRM may have failed).`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+});
+
+test.afterAll(async () => {
+  const cleanups: [string, () => Promise<void>][] = [
+    ["schedule", () => api.delete(`/scheduling/v1/schedules/${scheduleId}`)],
+    ["guardian link", () => api.delete(`/crm/v1/children/${childId}/guardians/${guardianId}`)],
+    ["guardian", () => api.deleteGuardian(guardianId)],
+    ["child", () => api.deleteChild(childId)],
+    ["time slot", () => api.deleteTimeSlot(timeSlotId)],
+    ["group", () => api.deleteGroup(groupId)],
+  ];
+  for (const [what, cleanup] of cleanups) {
+    try {
+      await cleanup();
+    } catch (error) {
+      console.warn(`Cleanup of ${what} failed:`, error);
+    }
+  }
+  await api.dispose();
+});
+
+test.describe("reports", () => {
+  test("newsletter lists the guardian email for the current month", async ({ page }) => {
+    await gotoApp(page, "/newsletter");
+
+    await expect(page.getByRole("heading", { name: "Nieuwsbrief" })).toBeVisible();
+    // Month/year selects default to the current month/year, which is exactly the
+    // period our seeded child is active in, so no need to change them.
+    await expect(page.getByRole("combobox", { name: "Jaar" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Maand" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Genereer" }).click();
+
+    await expect(page.getByText(guardianFullName)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(guardianEmail)).toBeVisible();
+    // Summary chips render as "<n> actieve kinderen" / "<n> e-mailadressen"
+    // (the digit prefix distinguishes them from the page description text).
+    await expect(page.getByText(/\d+ actieve kinderen/)).toBeVisible();
+    await expect(page.getByText(/\d+ e-mailadressen/)).toBeVisible();
+  });
+
+  test("print schedules form renders and generates in-page printable pages", async ({ page }) => {
+    await gotoApp(page, "/print-schedules");
+
+    await expect(
+      page.getByRole("heading", { name: "Afdrukken aanwezigheidsplanningen" }),
+    ).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Maand" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Jaar" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Groepen" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Genereer" }).click();
+
+    // The result renders in-page (one A4 "print-page" per group/weekday); the seeded
+    // group has scheduled children, so at least one page carries its name as heading.
+    await expect(page.getByRole("heading", { name: groupName }).first()).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByText(childFullName).first()).toBeVisible();
+    await expect(page.getByText("Legenda").first()).toBeVisible();
+
+    // The print trigger appears once data is rendered; window.print() opens the native
+    // dialog (no download event), so only assert it is enabled.
+    await expect(page.getByRole("button", { name: "Afdrukken" })).toBeEnabled();
+  });
+
+  test("print phone list shows the guardian phone number", async ({ page }) => {
+    await gotoApp(page, "/print-phone-list");
+
+    await expect(page.getByRole("heading", { name: "Telefoonlijst exporteren" })).toBeVisible();
+    // Year select defaults to the current year, in which the seeded child is active.
+    await expect(page.getByRole("combobox", { name: "Jaar" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Genereer" }).click();
+
+    // In-page table: child, linked guardian (relationship chip "Ouder") and the
+    // E.164 number formatted for display.
+    await expect(page.getByText(childFullName)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(guardianFullName)).toBeVisible();
+    await expect(page.getByText(guardianPhoneFormatted).first()).toBeVisible();
+    await expect(page.getByText(/Totaal kinderen/)).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/schedule-overview.spec.ts
+++ b/tests/e2e/specs/schedule-overview.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Use cases covered (task 2 — schedule overview, src/web/src/pages/ScheduleOverviewPage.tsx):
+ *  UC2.1 A scheduled child is shown inside its group column on a scheduled day.
+ *  UC2.2 Date navigation: next/previous day buttons change the ?date= URL param by one
+ *        day; the "Vandaag" button resets it to today.
+ *  UC2.3 A closure period renders the closure indication (chip/banner with the reason,
+ *        fallback "Gesloten") on the closed date.
+ *  UC2.4 An absence renders the absence indication (warning absent-count chip in the
+ *        group's "Dagoverzicht" summary) while the child card stays visible (dimmed).
+ *
+ * Seeding goes through the API helpers; schedule rules use .NET System.DayOfWeek
+ * (0 = Sunday .. 6 = Saturday) and cover all seven days so any picked date is scheduled.
+ */
+import { test, expect, type Page, type Locator } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+
+/** Format a Date as local YYYY-MM-DD (no UTC conversion surprises). */
+function isoDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function addDays(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  return isoDate(new Date(y, m - 1, d + days));
+}
+
+/** First Wednesday of the current month (a fixed, scheduled weekday). */
+function firstWednesdayOfCurrentMonth(): string {
+  const now = new Date();
+  const first = new Date(now.getFullYear(), now.getMonth(), 1);
+  const offset = (3 - first.getDay() + 7) % 7; // 3 = Wednesday
+  return isoDate(new Date(now.getFullYear(), now.getMonth(), 1 + offset));
+}
+
+/** The group column Paper that contains the group-name heading (GroupColumn.tsx). */
+function groupColumn(page: Page, groupName: string): Locator {
+  return page
+    .locator(".MuiPaper-root")
+    .filter({ has: page.getByRole("heading", { name: groupName }) });
+}
+
+const groupName = uniqueName("Groep");
+const childGivenName = uniqueName("Kind");
+const childFamilyName = "Planbord";
+const childFullName = `${childGivenName} ${childFamilyName}`;
+const closureReason = uniqueName("Studiedag");
+
+const scheduledDate = firstWednesdayOfCurrentMonth();
+const absenceDate = addDays(scheduledDate, 7); // another Wednesday
+const closureDate = addDays(scheduledDate, 14); // yet another Wednesday
+
+let api: Api;
+let groupId: string;
+let timeSlotId: string;
+let childId: string;
+let scheduleId: string;
+let closurePeriodId: string;
+let absenceId: string;
+
+test.beforeAll(async () => {
+  test.setTimeout(120_000); // seeding waits for CRM -> Scheduling replication
+
+  api = await Api.create();
+
+  groupId = await api.createGroup(groupName);
+  timeSlotId = await api.createTimeSlot({
+    name: uniqueName("Ochtend"),
+    startTime: "08:00:00",
+    endTime: "13:00:00",
+  });
+
+  const dob = new Date();
+  dob.setFullYear(dob.getFullYear() - 3); // ~3 years old
+  childId = await api.createChild({
+    givenName: childGivenName,
+    familyName: childFamilyName,
+    dateOfBirth: isoDate(dob),
+  });
+
+  // All days of the week (System.DayOfWeek: 0 = Sunday .. 6 = Saturday),
+  // starting in the past so every date used in these tests is covered.
+  scheduleId = await api.createSchedule({
+    childId,
+    startDate: "2024-01-01",
+    scheduleRules: [0, 1, 2, 3, 4, 5, 6].map((day) => ({ day, timeSlotId, groupId })),
+  });
+
+  closurePeriodId = await api.createClosurePeriod({
+    startDate: closureDate,
+    endDate: closureDate,
+    reason: closureReason,
+  });
+
+  absenceId = await api.addAbsence({
+    childId,
+    startDate: absenceDate,
+    endDate: absenceDate,
+    reason: "Ziek",
+  });
+});
+
+test.afterAll(async () => {
+  // Delete in dependency order; tolerate failures so one leftover doesn't mask the rest.
+  const cleanups: [string, () => Promise<void>][] = [
+    ["absence", () => api.delete(`/scheduling/v1/absences/${absenceId}`)],
+    ["closure period", () => api.deleteClosurePeriod(closurePeriodId)],
+    ["schedule", () => api.delete(`/scheduling/v1/schedules/${scheduleId}`)],
+    ["child", () => api.deleteChild(childId)],
+    ["time slot", () => api.deleteTimeSlot(timeSlotId)],
+    ["group", () => api.deleteGroup(groupId)],
+  ];
+  for (const [what, cleanup] of cleanups) {
+    try {
+      await cleanup();
+    } catch (error) {
+      console.warn(`Cleanup of ${what} failed:`, error);
+    }
+  }
+  await api.dispose();
+});
+
+test.describe("schedule overview", () => {
+  test("shows the scheduled child inside its group column", async ({ page }) => {
+    await gotoApp(page, `/schedule?date=${scheduledDate}`);
+
+    const column = groupColumn(page, groupName);
+    await expect(column.getByRole("heading", { name: groupName })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(column.getByText(childFullName)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("date navigation updates the date URL param", async ({ page }) => {
+    // Start far away from today so next/previous never lands on today
+    // (the "Vandaag" button is disabled when today is selected).
+    const start = addDays(isoDate(new Date()), 30);
+    await gotoApp(page, `/schedule?date=${start}`);
+
+    // The next/previous IconButtons have no accessible name, and MUI only emits
+    // icon data-testids in development builds (the dockerized app is a production
+    // build), so locate them inside the desktop header Paper (the one with the
+    // "Planningsoverzicht" page title): its only buttons are "Vandaag" plus the
+    // previous/next chevrons, in that DOM order.
+    const header = page
+      .locator(".MuiPaper-root")
+      .filter({ has: page.getByRole("heading", { name: "Planningsoverzicht" }) });
+    const chevrons = header.getByRole("button").filter({ hasNotText: "Vandaag" });
+    await expect(chevrons).toHaveCount(2, { timeout: 15_000 });
+    const previousDay = chevrons.first();
+    const nextDay = chevrons.last();
+
+    await nextDay.click();
+    await expect(page).toHaveURL(new RegExp(`[?&]date=${addDays(start, 1)}`));
+
+    await previousDay.click();
+    await expect(page).toHaveURL(new RegExp(`[?&]date=${start}`));
+
+    await previousDay.click();
+    await expect(page).toHaveURL(new RegExp(`[?&]date=${addDays(start, -1)}`));
+
+    await page.getByRole("button", { name: "Vandaag" }).click();
+    await expect(page).toHaveURL(new RegExp(`[?&]date=${isoDate(new Date())}`));
+  });
+
+  test("shows the closure indication on a closed day", async ({ page }) => {
+    await gotoApp(page, `/schedule?date=${closureDate}`);
+
+    // Header chip and each group column banner show the closure reason
+    // (falling back to "Gesloten" when no reason is set — we seeded a reason).
+    await expect(page.getByText(closureReason).first()).toBeVisible({ timeout: 15_000 });
+
+    // Our group column shows the closure banner instead of schedules.
+    const column = groupColumn(page, groupName);
+    await expect(column.getByText(closureReason)).toBeVisible();
+    await expect(column.getByText(childFullName)).toBeHidden();
+  });
+
+  test("shows the absence indication for an absent child", async ({ page }) => {
+    await gotoApp(page, `/schedule?date=${absenceDate}`);
+
+    const column = groupColumn(page, groupName);
+    // The absent child is still listed (dimmed) in the column...
+    await expect(column.getByText(childFullName)).toBeVisible({ timeout: 15_000 });
+    // ...and the group's daily summary ("Dagoverzicht" card, GroupSummary.tsx)
+    // shows the warning absent-count chip. MUI icon data-testids are stripped in
+    // production builds, so target the chip by its stable MUI warning-color class;
+    // the absent chip is the only warning Chip the summary renders, labeled with
+    // the absent count (exactly 1 for our uniquely named child).
+    const summary = column
+      .locator(".MuiCard-root")
+      .filter({ has: page.getByRole("heading", { name: "Dagoverzicht" }) });
+    const absentChip = summary.locator(".MuiChip-colorWarning");
+    await expect(absentChip).toBeVisible();
+    await expect(absentChip).toHaveText("1");
+  });
+});

--- a/tests/e2e/specs/settings-closure-periods.spec.ts
+++ b/tests/e2e/specs/settings-closure-periods.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Closure periods settings page (/settings/closure-periods).
+ *
+ * Covered use cases:
+ * - Add a closure period through the "Sluitingsperiode toevoegen" dialog
+ *   (reason + start/end date via the MUI DatePicker sections, nl format
+ *   DD-MM-YYYY) and see the row with the reason and YYYY-MM-DD-formatted
+ *   dates, plus the "Sluitingsperiode toegevoegd" snackbar.
+ * - Delete a closure period through the row delete action, including the
+ *   confirmation dialog ("Verwijder sluitingsperiode"), and see the row gone.
+ * - Cleanup: leftover closure periods created by this spec are removed via
+ *   the API.
+ */
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+
+type ClosurePeriodRow = { id: string; reason?: string };
+
+let api: Api;
+/** Reasons of closure periods that may be left behind (cleaned up by reason). */
+const createdReasons = new Set<string>();
+
+test.beforeAll(async () => {
+  api = await Api.create();
+});
+
+test.afterAll(async () => {
+  try {
+    const periods = await api.get<ClosurePeriodRow[]>("/scheduling/v1/closure-periods");
+    for (const period of periods) {
+      if (period.reason && createdReasons.has(period.reason)) {
+        try {
+          await api.deleteClosurePeriod(period.id);
+        } catch {
+          // Already deleted through the UI — fine.
+        }
+      }
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
+  await api.dispose();
+});
+
+/**
+ * Type a date into a MUI X DatePicker field (accessible DOM structure: a
+ * group of day/month/year spinbutton sections; nl display format DD-MM-YYYY,
+ * so type DDMMYYYY). Clicking the first section focuses it; typed digits fill
+ * a section and auto-advance.
+ */
+async function typeDate(page: Page, field: Locator, ddmmyyyy: string): Promise<void> {
+  await field.getByRole("spinbutton").first().click();
+  await page.keyboard.type(ddmmyyyy);
+}
+
+test("add a closure period via dialog", async ({ page }) => {
+  const reason = uniqueName("sluiting");
+  createdReasons.add(reason);
+
+  await gotoApp(page, "/settings/closure-periods");
+  await page.getByRole("button", { name: "Sluitingsperiode toevoegen" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("heading", { name: "Sluitingsperiode toevoegen" }),
+  ).toBeVisible();
+  await dialog.getByLabel("Reden", { exact: true }).fill(reason);
+  // 27-12-2030 t/m 31-12-2030 (far in the future, away from other test data).
+  await typeDate(page, dialog.getByRole("group", { name: "Startdatum" }), "27122030");
+  await typeDate(page, dialog.getByRole("group", { name: "Einddatum" }), "31122030");
+  await dialog.getByRole("button", { name: "Toevoegen" }).click();
+
+  await expect(page.getByText("Sluitingsperiode toegevoegd")).toBeVisible();
+  const row = page.getByRole("row").filter({ hasText: reason });
+  await expect(row.getByRole("gridcell", { name: reason, exact: true })).toBeVisible();
+  // The table formats dates as YYYY-MM-DD.
+  await expect(row.getByRole("gridcell", { name: "2030-12-27", exact: true })).toBeVisible();
+  await expect(row.getByRole("gridcell", { name: "2030-12-31", exact: true })).toBeVisible();
+});
+
+test("delete a closure period", async ({ page }) => {
+  const reason = uniqueName("sluiting");
+  createdReasons.add(reason);
+  await api.createClosurePeriod({
+    startDate: "2031-01-02",
+    endDate: "2031-01-03",
+    reason,
+  });
+
+  await gotoApp(page, "/settings/closure-periods");
+  const row = page.getByRole("row").filter({ hasText: reason });
+  await row.getByRole("button", { name: "Verwijder sluitingsperiode" }).click();
+
+  const confirmDialog = page.getByRole("dialog");
+  await expect(
+    confirmDialog.getByRole("heading", { name: "Verwijder sluitingsperiode" }),
+  ).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Verwijderen", exact: true }).click();
+
+  await expect(page.getByText("Sluitingsperiode is succesvol verwijderd")).toBeVisible();
+  await expect(page.getByRole("gridcell", { name: reason, exact: true })).toBeHidden();
+});

--- a/tests/e2e/specs/settings-groups.spec.ts
+++ b/tests/e2e/specs/settings-groups.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Groups settings page (/settings/groups).
+ *
+ * Covered use cases:
+ * - Add a group through the "Groep toevoegen" dialog and see the new row in
+ *   the DataGrid, with the "Groep toegevoegd" success snackbar.
+ * - Delete a group through the row delete action, including the confirmation
+ *   dialog ("Groep '<naam>' verwijderen"), and see the row disappear.
+ * - A group seeded directly through the API shows up in the table after a
+ *   page (re)load, proving the list renders server data.
+ * - Cleanup: leftover groups created by this spec are removed via the API.
+ */
+import { test, expect } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+
+type PagedList<T> = { value: T[]; meta: { total: number } };
+type GroupRow = { id: string; name?: string };
+
+let api: Api;
+/** Names of groups created through the UI (cleaned up by name in afterAll). */
+const uiCreatedNames = new Set<string>();
+/** Name of the group created in the "add" test, consumed by the "delete" test. */
+let addedGroupName: string | undefined;
+
+test.beforeAll(async () => {
+  api = await Api.create();
+});
+
+test.afterAll(async () => {
+  try {
+    const groups = await api.get<PagedList<GroupRow>>(
+      "/scheduling/v1/groups?pageNumber=1&pageSize=100",
+    );
+    for (const group of groups.value) {
+      if (group.name && uiCreatedNames.has(group.name)) {
+        try {
+          await api.deleteGroup(group.id);
+        } catch {
+          // Already deleted through the UI — fine.
+        }
+      }
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
+  await api.dispose();
+});
+
+test("add a group via dialog", async ({ page }) => {
+  const name = uniqueName("groep");
+  uiCreatedNames.add(name);
+
+  await gotoApp(page, "/settings/groups");
+  await page.getByRole("button", { name: "Groep", exact: true }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Groep toevoegen" })).toBeVisible();
+  await dialog.getByLabel("Naam", { exact: true }).fill(name);
+  await dialog.getByRole("button", { name: "Toevoegen" }).click();
+
+  await expect(page.getByText("Groep toegevoegd")).toBeVisible();
+  await expect(page.getByRole("gridcell", { name, exact: true })).toBeVisible();
+
+  addedGroupName = name;
+});
+
+test("delete a group", async ({ page }) => {
+  // Normally deletes the group created in the previous test; seeds its own
+  // group via the API when running stand-alone (e.g. on a CI retry).
+  let name = addedGroupName;
+  if (!name) {
+    name = uniqueName("groep");
+    uiCreatedNames.add(name);
+    await api.createGroup(name);
+  }
+
+  await gotoApp(page, "/settings/groups");
+  const row = page.getByRole("row").filter({ hasText: name });
+  await row.getByRole("button", { name: "Verwijder groep" }).click();
+
+  const confirmDialog = page.getByRole("dialog");
+  await expect(
+    confirmDialog.getByRole("heading", { name: `Groep '${name}' verwijderen` }),
+  ).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Verwijderen", exact: true }).click();
+
+  await expect(page.getByText(`Groep '${name}' succesvol verwijderd`)).toBeVisible();
+  await expect(page.getByRole("gridcell", { name, exact: true })).toBeHidden();
+});
+
+test("a group seeded via the API is listed after reload", async ({ page }) => {
+  const name = uniqueName("groep");
+  const id = await api.createGroup(name);
+  try {
+    await gotoApp(page, "/settings/groups");
+    await expect(page.getByRole("gridcell", { name, exact: true })).toBeVisible();
+  } finally {
+    try {
+      await api.deleteGroup(id);
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+});

--- a/tests/e2e/specs/settings-timeslots.spec.ts
+++ b/tests/e2e/specs/settings-timeslots.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Time slots settings page (/settings/scheduling).
+ *
+ * Covered use cases:
+ * - Add a time slot through the "Tijdslot toevoegen" dialog (name + start/end
+ *   time via the MUI TimeField sections) and see the row with name and
+ *   HH:mm-formatted times, plus the "Tijdslot toegevoegd" snackbar.
+ * - Edit a time slot through the row edit action ("Bewerken") and the
+ *   "Bewerk tijdslot" dialog; the renamed row appears, the old name is gone.
+ * - Delete a time slot through the row delete action, including the
+ *   confirmation dialog ("Verwijder tijdslot '<naam>'"), and see the row gone.
+ * - Cleanup: leftover time slots created by this spec are removed via the API.
+ */
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+import { Api, uniqueName } from "../helpers/api";
+
+type PagedList<T> = { value: T[]; meta: { total: number } };
+type TimeSlotRow = { id: string; name?: string };
+
+let api: Api;
+/** Names of time slots that may be left behind (cleaned up by name). */
+const createdNames = new Set<string>();
+
+test.beforeAll(async () => {
+  api = await Api.create();
+});
+
+test.afterAll(async () => {
+  try {
+    const timeSlots = await api.get<PagedList<TimeSlotRow>>(
+      "/scheduling/v1/timeslots?pageNumber=1&pageSize=100",
+    );
+    for (const timeSlot of timeSlots.value) {
+      if (timeSlot.name && createdNames.has(timeSlot.name)) {
+        try {
+          await api.deleteTimeSlot(timeSlot.id);
+        } catch {
+          // Already deleted through the UI — fine.
+        }
+      }
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
+  await api.dispose();
+});
+
+/**
+ * Type a time into a MUI X TimeField (accessible DOM structure: a group of
+ * hour/minute spinbutton sections, display format HH:mm). Clicking the first
+ * section focuses it; typed digits fill a section and auto-advance.
+ */
+async function typeTime(page: Page, field: Locator, digits: string): Promise<void> {
+  await field.getByRole("spinbutton").first().click();
+  await page.keyboard.type(digits);
+}
+
+test("add a time slot via dialog", async ({ page }) => {
+  const name = uniqueName("slot");
+  createdNames.add(name);
+
+  await gotoApp(page, "/settings/scheduling");
+  await page.getByRole("button", { name: "Tijdslot", exact: true }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Tijdslot toevoegen" })).toBeVisible();
+  await dialog.getByLabel("Naam", { exact: true }).fill(name);
+  await typeTime(page, dialog.getByRole("group", { name: "Starttijd" }), "0815");
+  await typeTime(page, dialog.getByRole("group", { name: "Eindtijd" }), "1230");
+  await dialog.getByRole("button", { name: "Toevoegen" }).click();
+
+  await expect(page.getByText("Tijdslot toegevoegd")).toBeVisible();
+  const row = page.getByRole("row").filter({ hasText: name });
+  await expect(row.getByRole("gridcell", { name, exact: true })).toBeVisible();
+  await expect(row.getByRole("gridcell", { name: "08:15", exact: true })).toBeVisible();
+  await expect(row.getByRole("gridcell", { name: "12:30", exact: true })).toBeVisible();
+});
+
+test("edit a time slot", async ({ page }) => {
+  const name = uniqueName("slot");
+  const newName = uniqueName("slot-edit");
+  createdNames.add(name);
+  createdNames.add(newName);
+  await api.createTimeSlot({ name, startTime: "09:00:00", endTime: "17:00:00" });
+
+  await gotoApp(page, "/settings/scheduling");
+  const row = page.getByRole("row").filter({ hasText: name });
+  await row.getByRole("button", { name: "Bewerken" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Bewerk tijdslot" })).toBeVisible();
+  await dialog.getByLabel("Naam", { exact: true }).fill(newName);
+  await dialog.getByRole("button", { name: "Bijwerken" }).click();
+
+  await expect(page.getByText("Tijdslot bijgewerkt")).toBeVisible();
+  await expect(page.getByRole("gridcell", { name: newName, exact: true })).toBeVisible();
+  await expect(page.getByRole("gridcell", { name, exact: true })).toBeHidden();
+});
+
+test("delete a time slot", async ({ page }) => {
+  const name = uniqueName("slot");
+  createdNames.add(name);
+  await api.createTimeSlot({ name, startTime: "07:30:00", endTime: "13:00:00" });
+
+  await gotoApp(page, "/settings/scheduling");
+  const row = page.getByRole("row").filter({ hasText: name });
+  await row.getByRole("button", { name: "Verwijder tijdslot" }).click();
+
+  const confirmDialog = page.getByRole("dialog");
+  await expect(
+    confirmDialog.getByRole("heading", { name: `Verwijder tijdslot '${name}'` }),
+  ).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Verwijderen", exact: true }).click();
+
+  await expect(page.getByText(`Tijdslot '${name}' is succesvol verwijderd.`)).toBeVisible();
+  await expect(page.getByRole("gridcell", { name, exact: true })).toBeHidden();
+});

--- a/tests/e2e/specs/settings.spec.ts
+++ b/tests/e2e/specs/settings.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Settings hub & EndMark automation settings.
+ *
+ * Covered use cases:
+ * - The settings hub (/settings) shows the four settings cards with their
+ *   Dutch titles (Tijdslots, Groepen, Sluitingsperiodes, Eindmarkering
+ *   automatisering) and navigates to the groups and time-slots pages.
+ * - The EndMark automation settings form (/settings/endmark-automation) can be
+ *   viewed, a value changed and saved, and the saved value persists across a
+ *   reload. (The app gives no success snackbar here: success is signalled by
+ *   the Save button returning to its disabled/pristine state and the absence
+ *   of the error alert.)
+ */
+import { test, expect } from "@playwright/test";
+import { gotoApp } from "../helpers/app";
+
+test.describe("settings hub", () => {
+  test("settings hub shows cards and navigates", async ({ page }) => {
+    await gotoApp(page, "/settings");
+
+    // Cards are MUI CardActionAreas (buttons); their accessible name contains
+    // title + description. Descriptions are unique per card.
+    const timeSlotsCard = page.getByRole("button", {
+      name: /Beheer tijdsloten voor planning/,
+    });
+    const groupsCard = page.getByRole("button", { name: /Beheer groepen/ });
+    const closurePeriodsCard = page.getByRole("button", {
+      name: /Beheer sluitingsperiodes voor planning/,
+    });
+    const endMarkCard = page.getByRole("button", {
+      name: /Configureer automatische eindmarkering voor kinderen/,
+    });
+
+    await expect(timeSlotsCard).toBeVisible();
+    await expect(groupsCard).toBeVisible();
+    await expect(closurePeriodsCard).toBeVisible();
+    await expect(endMarkCard).toBeVisible();
+
+    // Exact Dutch card titles.
+    await expect(page.getByText("Tijdslots", { exact: true })).toBeVisible();
+    await expect(page.getByText("Groepen", { exact: true })).toBeVisible();
+    await expect(page.getByText("Sluitingsperiodes", { exact: true })).toBeVisible();
+    await expect(page.getByText("Eindmarkering automatisering", { exact: true })).toBeVisible();
+
+    await groupsCard.click();
+    await expect(page).toHaveURL(/\/settings\/groups$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/settings$/);
+
+    await timeSlotsCard.click();
+    await expect(page).toHaveURL(/\/settings\/scheduling$/);
+  });
+});
+
+test.describe("endmark automation settings", () => {
+  test("endmark automation settings can be viewed and saved", async ({ page }) => {
+    await gotoApp(page, "/settings/endmark-automation");
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Instellingen voor eindmarkering automatisering",
+      }),
+    ).toBeVisible();
+
+    // Form fields (rendered once settings have loaded).
+    const yearsField = page.getByLabel("Jaren na de geboorte");
+    await expect(yearsField).toBeVisible();
+    await expect(page.getByText("Schakel automatische eindmarkering in")).toBeVisible();
+    await expect(page.getByLabel("Beschrijving sjabloon")).toBeVisible();
+
+    const saveButton = page.getByRole("button", { name: "Opslaan" });
+    // Pristine form: nothing modified yet.
+    await expect(saveButton).toBeDisabled();
+
+    // Pick a value that is guaranteed to differ from the current one.
+    const currentValue = await yearsField.inputValue();
+    const newValue = currentValue === "6" ? "7" : "6";
+    await yearsField.fill(newValue);
+    await expect(saveButton).toBeEnabled();
+
+    const putResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/scheduling/v1/endmarksettings") &&
+        response.request().method() === "PUT",
+    );
+    await saveButton.click();
+    expect((await putResponse).ok()).toBe(true);
+
+    // Success feedback: form returns to pristine state and no error alert.
+    await expect(saveButton).toBeDisabled();
+    await expect(
+      page.getByText("Bijwerken van instellingen mislukt. Probeer het opnieuw."),
+    ).toBeHidden();
+    await expect(yearsField).toHaveValue(newValue);
+
+    // Reload and verify the value persisted.
+    await gotoApp(page, "/settings/endmark-automation");
+    await expect(page.getByLabel("Jaren na de geboorte")).toHaveValue(newValue);
+  });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a Playwright end-to-end test suite: **36 tests across 10 spec files** covering all 29 user-facing use cases (catalog + coverage map in `docs/e2e-use-cases.md`). The suite runs the **real full stack** — web, Envoy gateway, CRM API, Scheduling API, PostgreSQL, RabbitMQ — in docker compose, with **no external dependencies or secrets** for auth.

### Coverage
- **Auth**: login bounce, deep-link `returnTo`, logout
- **Schedule overview**: group columns with scheduled children, date navigation, closed days, absence indication
- **Children**: list, search, create, edit, delete
- **Child planning**: view/add/delete schedules, end marks (incl. auto-generated ones)
- **Guardians**: list, search, create, edit, link/unlink child, delete
- **Reports**: newsletter recipients, print schedules, phone list
- **Settings**: hub navigation, groups / time slots / closure periods CRUD, end-mark automation settings

### How auth works without Auth0
`tests/e2e/mock-auth/server.mjs` is a ~200-line zero-dependency mock OIDC provider that auto-approves every login as a fixed test user with the expected tenant claim. The SPA runs its **unmodified** auth0-spa-js flow against it (redirect login, `web_message` silent auth, refresh tokens, logout); Envoy validates JWTs against its JWKS (`envoy.e2e.yaml`); the .NET APIs point at it via a new `Auth0:Authority` config override — the only production-code change (two lines per service, default behavior unchanged). Tests seed data through the real APIs with `client_credentials` tokens.

### Other pieces
- `src/docker-compose.e2e.yml` — e2e overrides; postgres has **no volume**, so every run starts from a clean DB
- `src/web/nginx/nginx.e2e.conf` — CSP-free SPA serving (prod CSP pins Auth0/prod domains)
- `.github/workflows/e2e.yml` — builds images with GHA layer caching (buildx bake), starts the stack, runs the suite; uploads Playwright report/traces + compose logs on failure; uses the existing `NUGET_GITHUB_TOKEN` secret

### Verification
- Full suite green twice locally: warm DB (36/36, 1.2 min) and a fresh stack with empty DB simulating CI (36/36, 1.4 min)
- `tsc --noEmit` clean
- Quirks the tests accommodate are documented in `tests/e2e/README.md` (prod builds strip MUI `data-testid`s; real i18n source is `src/web/src/locales`; async CRM→Scheduling replication; automatic end marks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)