### PR TITLE
ci: auto-enable merge on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+    - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+
+    steps:
+    - name: Enable auto-merge
+      run: gh pr merge --auto --rebase "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-automerge.yml`, which runs on every `pull_request` targeting `main`
- When the PR author is `dependabot[bot]`, it enables GitHub's native auto-merge (`gh pr merge --auto --rebase`) so the PR merges itself once required checks pass
- Uses `--rebase` since this repo only allows rebase merges (squash/merge-commit are disabled in repo settings)

Note: `main` branch protection currently requires 0 approvals and no required status check contexts, so auto-merge will complete as soon as the PR is mergeable. If you want dependency updates to wait on CI, add required status checks to branch protection.

## Test plan
- [ ] Confirm the workflow appears in the Actions tab after merge
- [ ] Wait for the next Dependabot PR and verify auto-merge gets enabled on it
- [ ] Optionally test manually by pushing a throwaway PR authored as `dependabot[bot]` (not easily doable without admin/app access) — otherwise verify via the next real Dependabot PR

https://claude.ai/code/session_01CGnqnuFsdvYGnz291SKxaf