### PR TITLE
fix(ci): resolve build warnings from e2e workflow run

### DIFF
--- a/src/Services/CRM/Api/Api.csproj
+++ b/src/Services/CRM/Api/Api.csproj
@@ -21,6 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Direct reference to lift the transitive Microsoft.OpenApi above GHSA-v5pm-xwqc-g5wc -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Services/CRM/Api/ConfigureServices.cs
+++ b/src/Services/CRM/Api/ConfigureServices.cs
@@ -62,7 +62,7 @@ public static class ConfigureServices
                 {
                     foreach (var parameter in operation.Parameters)
                     {
-                        if (parameter is OpenApiParameter p)
+                        if (parameter is OpenApiParameter p && !string.IsNullOrEmpty(p.Name))
                         {
                             p.Name = Char.ToLowerInvariant(p.Name[0]) + p.Name[1..];
                         }

--- a/src/Services/CRM/Api/Dockerfile
+++ b/src/Services/CRM/Api/Dockerfile
@@ -13,7 +13,7 @@ COPY ["Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.
 
 RUN dotnet restore "Services/CRM/Api/Api.csproj"
 
-FROM restore as build
+FROM restore AS build
 
 COPY Services/CRM Services/CRM
 COPY Shared Shared
@@ -25,7 +25,7 @@ RUN dotnet build "Api/Api.csproj" -c Release \
     --no-restore \
     --no-incremental
 
-FROM build as publish
+FROM build AS publish
 
 RUN dotnet publish "Api/Api.csproj" -c Release -o /app/publish \
     --verbosity minimal \
@@ -33,7 +33,7 @@ RUN dotnet publish "Api/Api.csproj" -c Release -o /app/publish \
     --no-build \
     /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 as runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 AS runtime
 
 EXPOSE 80
 EXPOSE 443

--- a/src/Services/CRM/Application/Contracts/Validation/ValidationError.cs
+++ b/src/Services/CRM/Application/Contracts/Validation/ValidationError.cs
@@ -2,8 +2,8 @@
 {
     public class ValidationError
     {
-        public string Code { get; set; }
-        public string Property { get; set; }
-        public string Title { get; set; }
+        public required string Code { get; set; }
+        public required string Property { get; set; }
+        public required string Title { get; set; }
     }
 }

--- a/src/Services/CRM/Infrastructure/Dockerfile
+++ b/src/Services/CRM/Infrastructure/Dockerfile
@@ -16,20 +16,20 @@ COPY ["Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.
 
 RUN dotnet restore "Services/CRM/Api/Api.csproj"
 
-FROM restore as build
+FROM restore AS build
 
 COPY Services/CRM Services/CRM
 COPY Shared Shared
 
 WORKDIR "/src/Services/CRM"
 
-FROM build as build-migrator
+FROM build AS build-migrator
 
 RUN dotnet tool install -g dotnet-ef --version 9.0.7
-ENV PATH $PATH:/root/.dotnet/tools
+ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet ef migrations bundle --self-contained -r linux-x64 --startup-project "./Api"
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.9 as migrator-runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.9 AS migrator-runtime
 
 COPY --from=build-migrator /src/Services/CRM/efbundle .
 

--- a/src/Services/CRM/Infrastructure/Infrastructure.csproj
+++ b/src/Services/CRM/Infrastructure/Infrastructure.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="MassTransit" Version="8.5.10" />
   <PackageReference Include="OpenTelemetry" Version="1.15.3" />
   <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/src/Services/Scheduling/Api/Api.csproj
+++ b/src/Services/Scheduling/Api/Api.csproj
@@ -31,5 +31,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
+    <!-- Direct reference to lift the transitive Microsoft.OpenApi above GHSA-v5pm-xwqc-g5wc -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 </Project>

--- a/src/Services/Scheduling/Api/Dockerfile
+++ b/src/Services/Scheduling/Api/Dockerfile
@@ -11,12 +11,12 @@ COPY ["Shared/KDVManager.Shared.Contracts/KDVManager.Shared.Contracts.csproj", "
 COPY ["Shared/KDVManager.Shared.Domain/KDVManager.Shared.Domain.csproj", "Shared/KDVManager.Shared.Domain/"]
 COPY ["Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj", "Shared/KDVManager.Shared.Infrastructure/"]
 
-ARG NUGET_GITHUB_TOKEN
-RUN dotnet nuget add source "https://nuget.pkg.github.com/LuukLabs/index.json" --name "github" --username "LuukVH" --password "$NUGET_GITHUB_TOKEN" --store-password-in-clear-text
+RUN --mount=type=secret,id=nuget_github_token \
+    dotnet nuget add source "https://nuget.pkg.github.com/LuukLabs/index.json" --name "github" --username "LuukVH" --password "$(cat /run/secrets/nuget_github_token)" --store-password-in-clear-text
 
 RUN dotnet restore "Services/Scheduling/Api/Api.csproj"
 
-FROM restore as build
+FROM restore AS build
 
 COPY Services/Scheduling Services/Scheduling
 COPY Shared Shared
@@ -28,7 +28,7 @@ RUN dotnet build "Api/Api.csproj" -c Release \
     --no-restore \
     --no-incremental
 
-FROM build as publish
+FROM build AS publish
 
 RUN dotnet publish "Api/Api.csproj" -c Release -o /app/publish \
     --verbosity minimal \
@@ -36,7 +36,7 @@ RUN dotnet publish "Api/Api.csproj" -c Release -o /app/publish \
     --no-build \
     /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 as runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 AS runtime
 
 EXPOSE 80
 EXPOSE 443

--- a/src/Services/Scheduling/Application/Contracts/Validation/ValidationError.cs
+++ b/src/Services/Scheduling/Application/Contracts/Validation/ValidationError.cs
@@ -2,7 +2,7 @@
 
 public class ValidationError
 {
-    public string Code { get; set; }
-    public string Property { get; set; }
-    public string Title { get; set; }
+    public required string Code { get; set; }
+    public required string Property { get; set; }
+    public required string Title { get; set; }
 }

--- a/src/Services/Scheduling/Application/Features/Groups/Commands/AddGroup/AddGroupCommand.cs
+++ b/src/Services/Scheduling/Application/Features/Groups/Commands/AddGroup/AddGroupCommand.cs
@@ -4,5 +4,5 @@ namespace KDVManager.Services.Scheduling.Application.Features.Groups.Commands.Ad
 
 public class AddGroupCommand
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 }

--- a/src/Services/Scheduling/Application/Features/Groups/Queries/ListGroups/GroupListVM.cs
+++ b/src/Services/Scheduling/Application/Features/Groups/Queries/ListGroups/GroupListVM.cs
@@ -5,7 +5,7 @@ namespace KDVManager.Services.Scheduling.Application.Features.Groups.Queries.Lis
 public class GroupListVM
 {
     public Guid Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
 }
 

--- a/src/Services/Scheduling/Application/Features/Schedules/Queries/GetChildSchedules/ChildScheduleListVM.cs
+++ b/src/Services/Scheduling/Application/Features/Schedules/Queries/GetChildSchedules/ChildScheduleListVM.cs
@@ -17,11 +17,11 @@ public class ChildScheduleListVM
     {
         public DayOfWeek Day { get; set; }
         public Guid TimeSlotId { get; set; }
-        public string TimeSlotName { get; set; }
+        public string TimeSlotName { get; set; } = string.Empty;
         public TimeOnly StartTime { get; set; }
         public TimeOnly EndTime { get; set; }
         public Guid GroupId { get; set; }
-        public string GroupName { get; set; }
+        public string GroupName { get; set; } = string.Empty;
     }
 }
 

--- a/src/Services/Scheduling/Application/Features/Schedules/Queries/GetChildSchedules/ScheduleDto.cs
+++ b/src/Services/Scheduling/Application/Features/Schedules/Queries/GetChildSchedules/ScheduleDto.cs
@@ -9,8 +9,8 @@ public class ScheduleDto
     public Guid Id { get; set; }
     public Guid ChildId { get; set; }
     public Guid GroupId { get; set; }
-    public string GroupName { get; set; }
+    public string GroupName { get; set; } = string.Empty;
     public DateOnly StartDate { get; set; }
     public DateOnly? EndDate { get; set; }
-    public ICollection<ScheduleRule> ScheduleRules { get; set; }
+    public ICollection<ScheduleRule> ScheduleRules { get; set; } = new List<ScheduleRule>();
 }

--- a/src/Services/Scheduling/Application/Features/TimeSlots/Commands/AddTimeSlot/AddTimeSlotCommand.cs
+++ b/src/Services/Scheduling/Application/Features/TimeSlots/Commands/AddTimeSlot/AddTimeSlotCommand.cs
@@ -4,7 +4,7 @@ namespace KDVManager.Services.Scheduling.Application.Features.TimeSlots.Commands
 
 public class AddTimeSlotCommand
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     public TimeOnly StartTime { get; set; }
 

--- a/src/Services/Scheduling/Application/Features/TimeSlots/Commands/UpdateTimeSlot/UpdateTimeSlotCommand.cs
+++ b/src/Services/Scheduling/Application/Features/TimeSlots/Commands/UpdateTimeSlot/UpdateTimeSlotCommand.cs
@@ -6,7 +6,7 @@ public class UpdateTimeSlotCommand
 {
     public Guid Id { get; set; }
 
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     public TimeOnly StartTime { get; set; }
 

--- a/src/Services/Scheduling/Application/Features/TimeSlots/Queries/ListTimeSlots/TimeSlotListVM.cs
+++ b/src/Services/Scheduling/Application/Features/TimeSlots/Queries/ListTimeSlots/TimeSlotListVM.cs
@@ -5,7 +5,7 @@ namespace KDVManager.Services.Scheduling.Application.Features.TimeSlots.Queries.
 public class TimeSlotListVM
 {
     public Guid Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
     public TimeOnly StartTime { get; set; }
     public TimeOnly EndTime { get; set; }
 }

--- a/src/Services/Scheduling/Domain/Entities/ScheduleRule.cs
+++ b/src/Services/Scheduling/Domain/Entities/ScheduleRule.cs
@@ -13,7 +13,8 @@ public class ScheduleRule : IMustHaveTenant
     public Guid GroupId { get; set; }
     [Required]
     public Guid TimeSlotId { get; set; }
-    public TimeSlot TimeSlot { get; set; }
-    public Group Group { get; set; }
-    public Schedule Schedule { get; set; }
+    // EF Core navigation properties, populated by the framework when included in a query.
+    public TimeSlot TimeSlot { get; set; } = null!;
+    public Group Group { get; set; } = null!;
+    public Schedule Schedule { get; set; } = null!;
 }

--- a/src/Services/Scheduling/Infrastructure/Dockerfile
+++ b/src/Services/Scheduling/Infrastructure/Dockerfile
@@ -11,25 +11,25 @@ COPY ["Shared/KDVManager.Shared.Domain/KDVManager.Shared.Domain.csproj", "Shared
 COPY ["Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj", "Shared/KDVManager.Shared.Infrastructure/"]
 
 # Set up github source for NuGet packages
-ARG NUGET_GITHUB_TOKEN
-RUN dotnet nuget add source "https://nuget.pkg.github.com/LuukLabs/index.json" --name "github" --username "LuukVH" --password "$NUGET_GITHUB_TOKEN" --store-password-in-clear-text
+RUN --mount=type=secret,id=nuget_github_token \
+    dotnet nuget add source "https://nuget.pkg.github.com/LuukLabs/index.json" --name "github" --username "LuukVH" --password "$(cat /run/secrets/nuget_github_token)" --store-password-in-clear-text
 
 RUN dotnet restore "Services/Scheduling/Api/Api.csproj"
 
-FROM restore as build
+FROM restore AS build
 
 COPY Services/Scheduling Services/Scheduling
 COPY Shared Shared
 
 WORKDIR "/src/Services/Scheduling"
 
-FROM build as build-migrator
+FROM build AS build-migrator
 
 RUN dotnet tool install -g dotnet-ef --version 9.0.7
-ENV PATH $PATH:/root/.dotnet/tools
+ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet ef migrations bundle --self-contained -r linux-x64 --project ./Infrastructure --startup-project ./Api
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.9 as migrator-runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.9 AS migrator-runtime
 
 COPY --from=build-migrator /src/Services/Scheduling/efbundle .
 

--- a/src/Services/Scheduling/Infrastructure/Infrastructure.csproj
+++ b/src/Services/Scheduling/Infrastructure/Infrastructure.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="MassTransit" Version="8.5.10" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.10" />
   </ItemGroup>

--- a/src/Services/Scheduling/Infrastructure/Repositories/BaseRepository.cs
+++ b/src/Services/Scheduling/Infrastructure/Repositories/BaseRepository.cs
@@ -31,7 +31,9 @@ public class BaseRepository<T> : IAsyncRepository<T> where T : class
 
     public async Task<T> GetByIdAsync(Guid id)
     {
-        return await _dbContext.Set<T>().FindAsync(id);
+        // Interface expects non-null; callers should verify existence via ExistsAsync when needed.
+        // Suppress possible null warning with null-forgiving operator.
+        return (await _dbContext.Set<T>().FindAsync(id))!;
     }
 
     public async Task<IReadOnlyList<T>> ListAllAsync()

--- a/src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj
+++ b/src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="MassTransit.Abstractions" Version="8.5.10" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="OpenTelemetry" Version="1.15.3" />

--- a/src/Shared/KDVManager.Shared.Infrastructure/Logging/LoggingExtensions.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Logging/LoggingExtensions.cs
@@ -47,7 +47,7 @@ public static class LoggingExtensions
                 var instanceId = Environment.GetEnvironmentVariable("SERVICE_INSTANCE_ID") ?? Guid.NewGuid().ToString();
                 otel.SetResourceBuilder(ResourceBuilder.CreateDefault()
                     .AddService(serviceName: serviceName, serviceVersion: GetVersion(), serviceInstanceId: instanceId)
-                    .AddAttributes(new KeyValuePair<string, object?>[]
+                    .AddAttributes(new KeyValuePair<string, object>[]
                     {
                         new("deployment.environment", configuration["ASPNETCORE_ENVIRONMENT"] ?? "Production"),
                         new("service.namespace", "KDVManager"),

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/ITenancyResolver.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/ITenancyResolver.cs
@@ -4,5 +4,5 @@ namespace KDVManager.Shared.Infrastructure.Tenancy;
 
 public interface ITenancyResolver
 {
-    ITenancyContext Resolve();
+    ITenancyContext? Resolve();
 }

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/JwtTenancyResolver.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/JwtTenancyResolver.cs
@@ -14,7 +14,7 @@ public class JwtTenancyResolver : ITenancyResolver
         _accessor = accessor;
     }
 
-    public ITenancyContext Resolve()
+    public ITenancyContext? Resolve()
     {
         var claims = _http.HttpContext?.User?.Claims;
         if (claims == null)

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   envoy:
     volumes:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,4 +1,6 @@
-version: '3.4'
+secrets:
+  nuget_github_token:
+    environment: NUGET_GITHUB_TOKEN
 
 services:
   envoy:
@@ -55,8 +57,8 @@ services:
     build:
       context: .
       dockerfile: Services/Scheduling/Api/Dockerfile
-      args:
-        - NUGET_GITHUB_TOKEN=${NUGET_GITHUB_TOKEN}
+      secrets:
+        - nuget_github_token
     depends_on:
       - postgres
       - rabbitmq
@@ -66,8 +68,8 @@ services:
     build:
       context: .
       dockerfile: Services/Scheduling/Infrastructure/Dockerfile
-      args:
-        - NUGET_GITHUB_TOKEN=${NUGET_GITHUB_TOKEN}
+      secrets:
+        - nuget_github_token
     depends_on:
       - postgres
 

--- a/src/web/eslint.config.ts
+++ b/src/web/eslint.config.ts
@@ -172,6 +172,7 @@ const config = tseslint.config([
               "YYYY-MM-DD",
               "DD MMM",
               "DD MMM YYYY",
+              "MMMM",
               "[\\+\\-]?\\d+",
               "page",
               "size",

--- a/src/web/pnpm-workspace.yaml
+++ b/src/web/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   browser-tabs-lock: false
+  core-js-pure: false
   esbuild: true


### PR DESCRIPTION
Fixes the warnings surfaced in [e2e workflow run 28463424126](https://github.com/LuukLabs/KDVManager/actions/runs/28463424126).

## Docker
- **FromAsCasing** — `as` → `AS` in all four service Dockerfiles.
- **LegacyKeyValueFormat** — `ENV PATH=...` key=value form in both migrator Dockerfiles.
- **SecretsUsedInArgOrEnv** — `NUGET_GITHUB_TOKEN` is now passed as a BuildKit secret mount instead of a build `ARG`, so the token no longer persists in image layers. The compose files define an `environment:`-sourced secret, so all existing CI paths (`docker compose build` in the composite actions, `docker buildx bake` in e2e) keep working unchanged — verified locally that bake resolves the secret and that `compose config`/`up` are clean when the variable is unset (fixes the "variable is not set" warnings in the Start stack step).
- **Obsolete `version` attribute** removed from docker-compose.yml and docker-compose.override.yml.

## .NET
- **NU1903** — transitive `Microsoft.OpenApi` (2.0.0 via Microsoft.AspNetCore.OpenApi in CRM, 2.4.1 via Swashbuckle in Scheduling) has a known high-severity vulnerability (GHSA-v5pm-xwqc-g5wc). Added direct references to the patched 2.7.5.
- **CS8603** — `ITenancyResolver.Resolve()` is now declared nullable (the only caller already null-checks); Scheduling `BaseRepository.GetByIdAsync` uses the same null-forgiving pattern CRM already had.
- **CS8618** — `ValidationError` properties are `required` (all call sites use full object initializers); DTO/command string properties default to `string.Empty` to avoid changing JSON model-binding behavior; `ScheduleRule` EF navigation properties use `null!`.
- **CS8602** — guard against null/empty parameter names in the CRM OpenAPI operation transformer.
- **CS8620** — attribute array in `LoggingExtensions` typed as non-nullable `object` (all values are non-null).

Verified by building all five images locally: **0 compiler warnings, 0 NuGet warnings, 0 Dockerfile lint warnings**. Not addressed: the Vite chunk-size notice for the web bundle (needs actual code-splitting work, out of scope here) and the punycode/checkout hints that come from the runner itself.