### PR TITLE
ci: skip unaffected image builds and cache docker layers

### DIFF
--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
   nuget_github_token:
     description: "GitHub NuGet token for private packages"
-  
+
 runs:
   using: "composite"
   steps:
@@ -42,9 +42,19 @@ runs:
       echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
     shell: bash
 
-  - name: Compose build ${{ inputs.service }}
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v3
+
+  - name: Expose GitHub Actions runtime for build cache
+    uses: crazy-max/ghaction-github-runtime@v3
+
+  - name: Build ${{ inputs.service }}
     shell: bash
-    run: sudo -E docker compose  -f docker-compose.yml build ${{ inputs.service }}
+    run: |
+      docker buildx bake -f docker-compose.yml "${{ inputs.service }}" \
+        --set "${{ inputs.service }}.cache-from=type=gha,scope=${{ inputs.service }}" \
+        --set "${{ inputs.service }}.cache-to=type=gha,scope=${{ inputs.service }},mode=max" \
+        --load
     working-directory: ./src
     env:
       TAG: ${{ env.BRANCH }}
@@ -59,9 +69,9 @@ runs:
       echo "Tagging $image as $sha_tag"
       docker tag "$image" "$sha_tag"
 
-  - name: Compose push  -f docker-compose.yml ${{ inputs.service }}
+  - name: Push ${{ inputs.service }}
     shell: bash
-    run: sudo -E docker compose push ${{ inputs.service }}
+    run: docker compose -f docker-compose.yml push ${{ inputs.service }}
     working-directory: ./src
     env:
       TAG: ${{ env.BRANCH }}

--- a/.github/workflows/composite/build/action.yml
+++ b/.github/workflows/composite/build/action.yml
@@ -15,9 +15,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Compose build ${{ inputs.service }}
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v3
+
+  - name: Expose GitHub Actions runtime for build cache
+    uses: crazy-max/ghaction-github-runtime@v3
+
+  - name: Build ${{ inputs.service }}
     shell: bash
-    run: sudo -E docker compose build ${{ inputs.service }}
+    run: |
+      docker buildx bake -f docker-compose.yml "${{ inputs.service }}" \
+        --set "${{ inputs.service }}.cache-from=type=gha,scope=${{ inputs.service }}" \
+        --set "${{ inputs.service }}.cache-to=type=gha,scope=${{ inputs.service }},mode=max"
     working-directory: ./src
     env:
       TAG: ${{ env.BRANCH }}

--- a/.github/workflows/crm-api.yml
+++ b/.github/workflows/crm-api.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
     - main
+    paths:
+    - src/Services/CRM/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
+    - .github/workflows/crm-api.yml
   
   pull_request:
     branches:
@@ -12,6 +18,9 @@ on:
 
     paths:
     - src/Services/CRM/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
     - .github/workflows/crm-api.yml
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/crm-migrator.yml
+++ b/.github/workflows/crm-migrator.yml
@@ -5,13 +5,22 @@ on:
   push:
     branches:
     - main
+    paths:
+    - src/Services/CRM/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
+    - .github/workflows/crm-migrator.yml
   
   pull_request:
     branches:
     - main
 
     paths:
-    - src/Services/CRM/Persistence/**
+    - src/Services/CRM/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
     - .github/workflows/crm-migrator.yml
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy-update-images.yml
+++ b/.github/workflows/deploy-update-images.yml
@@ -9,9 +9,14 @@ on:
       - 'src/web/**'
       - 'src/Services/CRM/**'
       - 'src/Services/Scheduling/**'
+      - 'src/Shared/**'
+      - 'src/docker-compose.yml'
       - '.github/workflows/web.yml'
       - '.github/workflows/crm-api.yml'
+      - '.github/workflows/crm-migrator.yml'
       - '.github/workflows/scheduling-api.yml'
+      - '.github/workflows/scheduling-migrator.yml'
+      - '.github/workflows/composite/**'
       - '.github/workflows/deploy-update-images.yml'
 
 permissions:
@@ -39,7 +44,7 @@ jobs:
       - name: Update kustomize image tags (changed services)
         env:
           CHANGED_ONLY: true
-          BASE_REF: origin/main
+          BASE_SHA: ${{ github.event.before }}
         run: |
           bash scripts/update-kustomize-images.sh
 

--- a/.github/workflows/scheduling-api.yml
+++ b/.github/workflows/scheduling-api.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
     - main
+    paths:
+    - src/Services/Scheduling/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
+    - .github/workflows/scheduling-api.yml
   
   pull_request:
     branches:
@@ -12,6 +18,9 @@ on:
 
     paths:
     - src/Services/Scheduling/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
     - .github/workflows/scheduling-api.yml
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/scheduling-migrator.yml
+++ b/.github/workflows/scheduling-migrator.yml
@@ -8,13 +8,22 @@ on:
   push:
     branches:
     - main
+    paths:
+    - src/Services/Scheduling/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
+    - .github/workflows/scheduling-migrator.yml
   
   pull_request:
     branches:
     - main
 
     paths:
-    - src/Services/Scheduling/Persistence/**
+    - src/Services/Scheduling/**
+    - src/Shared/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
     - .github/workflows/scheduling-migrator.yml
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
     - main
+    paths:
+    - src/web/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
+    - .github/workflows/web.yml
   
   pull_request:
     branches:
@@ -12,6 +17,8 @@ on:
 
     paths:
     - src/web/**
+    - src/docker-compose.yml
+    - .github/workflows/composite/**
     - .github/workflows/web.yml
 env:
   REGISTRY: ghcr.io

--- a/scripts/update-kustomize-images.sh
+++ b/scripts/update-kustomize-images.sh
@@ -1,31 +1,69 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Updates kustomization image tags for all services.
+# Updates kustomization image tags for services.
 # Tag strategy: linux-<short-sha>
 # Assumes images already pushed by respective build workflows.
+#
+# When CHANGED_ONLY=true and BASE_SHA points to a valid commit, only services
+# whose source paths changed between BASE_SHA and the current SHA are updated.
+# The path lists below must stay in sync with the `paths` filters of the build
+# workflows, so a tag is never set for an image that was not built.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 K8S_APPS_DIR="$ROOT_DIR/deploy/k8s/applications"
 GIT_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
 SHORT_SHA=${GIT_SHA:0:7}
 TAG="linux-${SHORT_SHA}"
+CHANGED_ONLY=${CHANGED_ONLY:-false}
+BASE_SHA=${BASE_SHA:-}
 
-# Map logical service identifiers to kustomize subfolders and image names
-# Format: folder|image1,image2
+# Map logical service identifiers to kustomize subfolders, image names and
+# source path prefixes. Format: folder|image1,image2|path1,path2
 # Migrators share same tag as api builds.
 MAPPINGS=(
-  "web|ghcr.io/luuklabs/kdvmanager/web"
-  "crm|ghcr.io/luuklabs/kdvmanager/crm.api,ghcr.io/luuklabs/kdvmanager/crm.migrator"
-  "scheduling|ghcr.io/luuklabs/kdvmanager/scheduling.api,ghcr.io/luuklabs/kdvmanager/scheduling.migrator"
+  "web|ghcr.io/luuklabs/kdvmanager/web|src/web/,.github/workflows/web.yml"
+  "crm|ghcr.io/luuklabs/kdvmanager/crm.api,ghcr.io/luuklabs/kdvmanager/crm.migrator|src/Services/CRM/,src/Shared/,.github/workflows/crm-api.yml,.github/workflows/crm-migrator.yml"
+  "scheduling|ghcr.io/luuklabs/kdvmanager/scheduling.api,ghcr.io/luuklabs/kdvmanager/scheduling.migrator|src/Services/Scheduling/,src/Shared/,.github/workflows/scheduling-api.yml,.github/workflows/scheduling-migrator.yml"
 )
 
+# Path prefixes that affect every image build.
+SHARED_PATHS="src/docker-compose.yml,.github/workflows/composite/"
+
+CHANGED_FILES=""
+if [[ "$CHANGED_ONLY" == "true" ]]; then
+  if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git -C "$ROOT_DIR" cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+    echo "CHANGED_ONLY requested but base commit '${BASE_SHA}' unavailable; updating all services"
+    CHANGED_ONLY=false
+  else
+    CHANGED_FILES=$(git -C "$ROOT_DIR" diff --name-only "$BASE_SHA" "$GIT_SHA")
+    echo "Changed files since ${BASE_SHA:0:7}:"
+    echo "$CHANGED_FILES"
+  fi
+fi
+
+paths_changed() {
+  local prefix file
+  for prefix in "$@"; do
+    while IFS= read -r file; do
+      [[ -n "$file" && "$file" == "$prefix"* ]] && return 0
+    done <<< "$CHANGED_FILES"
+  done
+  return 1
+}
+
 for mapping in "${MAPPINGS[@]}"; do
-  folder="${mapping%%|*}"
-  images_csv="${mapping#*|}"
+  folder="$(cut -d'|' -f1 <<< "$mapping")"
+  images_csv="$(cut -d'|' -f2 <<< "$mapping")"
+  paths_csv="$(cut -d'|' -f3 <<< "$mapping"),$SHARED_PATHS"
   kustomization_dir="$K8S_APPS_DIR/$folder"
   if [[ ! -f "$kustomization_dir/kustomization.yaml" ]]; then
     echo "Missing kustomization for $folder, skipping"; continue
+  fi
+  IFS=',' read -r -a service_paths <<< "$paths_csv"
+  if [[ "$CHANGED_ONLY" == "true" ]] && ! paths_changed "${service_paths[@]}"; then
+    echo "No changes for $folder since ${BASE_SHA:0:7}; skipping"
+    continue
   fi
   IFS=',' read -r -a images <<< "$images_csv"
   for img in "${images[@]}"; do


### PR DESCRIPTION
## Problem

Every push to `main` rebuilt **all** images — e.g. [this run](https://github.com/LuukLabs/KDVManager/actions/runs/28617074684) built the CRM migrator for a playwright bump in `src/web`. The `paths` filters only existed on the `pull_request` triggers; `push` was unfiltered.

Filtering pushes alone would break deploys: `update-kustomize-images.sh` ignored the `CHANGED_ONLY` env the deploy workflow already passed and unconditionally bumped every service tag to `linux-<sha>` — which would then reference images that were never built.

## Changes

**Skip whole jobs (biggest win)**
- `paths` filters on the `push` trigger of all five image workflows, matched on the PR triggers. Each dotnet service filters on its own `src/Services/<X>/**` plus `src/Shared/**`, `src/docker-compose.yml`, and the composite actions (all of which feed the image).
- Fixed the migrator PR filters: they watched `src/Services/*/Persistence/**`, which doesn't exist, so migrator PR builds never triggered on real changes.
- Implemented `CHANGED_ONLY` in `update-kustomize-images.sh`: it diffs `BASE_SHA` (`github.event.before`) against the pushed SHA and only bumps tags for services whose build paths changed. Falls back to bumping everything when the base commit is unavailable (`workflow_dispatch`, force-push). The per-service path lists mirror the workflow `paths` filters so a tag bump always references an image that was built.

**Speed up the builds that do run**
- Composite actions now build via `docker buildx bake -f docker-compose.yml` with `type=gha` layer cache (scoped per service, `mode=max`), so the `dotnet restore` / SDK layers are reused across runs. Verified locally with `bake --print` that targets, tags, and `NUGET_GITHUB_TOKEN` build args resolve identically to `docker compose build`.
- Dropped `sudo` — root's docker config wouldn't see the buildx builder, and the runner user is in the docker group anyway.

## Verification

- All changed YAML parses; `bash -n` on the script.
- Script tested against real history with a stubbed kustomize:
  - web-only commit → crm + scheduling skipped
  - `src/Shared` commit → crm + scheduling bumped, web skipped
  - empty / all-zero `BASE_SHA` → falls back to bumping all services

## Notes

- First run after merge builds cold and pays a one-time cache export (~30s extra); later runs reuse the restore layers.
- The GHA cache has a 10 GB/repo limit; with 5 image scopes at `mode=max` old entries may evict under pressure — worst case is a cold build, never a failure.
- `feat/brand-marketing-and-app-theme` adds a marketing service; on merge, `marketing.yml` needs the same push `paths` filter and the script needs a `marketing|ghcr.io/luuklabs/kdvmanager/marketing|src/marketing/,.github/workflows/marketing.yml` mapping.

https://claude.ai/code/session_015X6ocMGJBmrZYmeKTDaSPc