### PR TITLE
fix(ci): use valid version syntax for MassTransit Dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,7 @@ updates:
           - "MassTransit*"
     ignore:
       - dependency-name: "MassTransit*"
-        versions: ["[9.0.0,)"]
+        versions: [">= 9.0.0"]
 
   - package-ecosystem: "docker"
     directories:


### PR DESCRIPTION
## Summary

The weekly NuGet Dependabot run fails with `illformed_requirement` ([example run](https://github.com/LuukLabs/KDVManager/actions/runs/28617597099/job/84865163883)) because the MassTransit ignore rule uses NuGet interval notation:

```yaml
versions: ["[9.0.0,)"]
```

The `versions` field in `dependabot.yml` doesn't accept this notation, so the updater aborts before checking any packages. This replaces it with the equivalent comparison syntax:

```yaml
versions: [">= 9.0.0"]
```

Semantics are unchanged: MassTransit 9.0.0 and above (the paid-license versions) stay ignored.

https://claude.ai/code/session_01AZ4a8FefzsQZJbrTZMASMq