### PR TITLE
ci: require all builds to succeed before merging via merge gate

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,70 @@
+name: merge-gate
+
+# Runs on every PR (no paths filter) and waits for all other check runs on the
+# head commit to complete. Path-filtered workflows that never trigger simply
+# don't report a check run, so they don't block. Mark only the "all-checks"
+# job as a required status check in branch protection.
+#
+# Note: if you re-run a failed workflow and it passes, re-run this gate too so
+# it picks up the new conclusion.
+
+on:
+  pull_request:
+    branches:
+    - main
+
+permissions:
+  checks: read
+
+jobs:
+  all-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+    - name: Wait for all other checks
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const ownName = 'all-checks';
+          const ref = context.payload.pull_request.head.sha;
+          const failedConclusions = ['failure', 'timed_out', 'cancelled', 'action_required'];
+          const initialDelayMs = 30_000;
+          const pollIntervalMs = 30_000;
+          const timeoutMs = 55 * 60_000;
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          // Give sibling workflows triggered by the same event time to
+          // register their check runs before the first poll.
+          await sleep(initialDelayMs);
+
+          const start = Date.now();
+          for (;;) {
+            const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+              ...context.repo,
+              ref,
+              filter: 'latest',
+              per_page: 100,
+            });
+            const others = checkRuns.filter((run) => run.name !== ownName);
+
+            const failed = others.filter((run) => failedConclusions.includes(run.conclusion));
+            if (failed.length > 0) {
+              core.setFailed(`Failed checks: ${failed.map((run) => run.name).join(', ')}`);
+              return;
+            }
+
+            const pending = others.filter((run) => run.status !== 'completed');
+            if (pending.length === 0) {
+              core.info(`All ${others.length} other checks completed successfully or were skipped.`);
+              return;
+            }
+
+            if (Date.now() - start > timeoutMs) {
+              core.setFailed(`Timed out waiting for: ${pending.map((run) => run.name).join(', ')}`);
+              return;
+            }
+
+            core.info(`Waiting for: ${pending.map((run) => run.name).join(', ')}`);
+            await sleep(pollIntervalMs);
+          }


### PR DESCRIPTION
## Problem

All CI workflows (`crm-api`, `scheduling-api`, `web`, `e2e`, the migrators) use `paths:` filters on `pull_request`, so most of them are skipped on any given PR. Their job names therefore can't be used as required status checks in branch protection: a PR that doesn't touch the filtered paths would show the check as *Expected* forever and could never merge.

## Solution

Add a `merge-gate` workflow with a single `all-checks` job that runs on **every** PR (no paths filter). It polls the Checks API for the head commit and:

- **fails** if any other check run concluded `failure`, `timed_out`, `cancelled`, or `action_required`
- **passes** once all other check runs completed (`success`, `neutral`, and `skipped` all count as OK)
- workflows that never trigger due to paths filters simply don't report a check run, so they don't block

Only `all-checks` is marked as a required status check in branch protection, which now enforces that every build that *did* run succeeded before merging.

Implemented with an inline `actions/github-script` step — no third-party actions. 30s initial delay so sibling workflows can register their check runs, 30s poll interval, 55-minute wait budget (e2e has a 40-minute timeout).

## Notes

- If a failed workflow is re-run and passes, re-run the gate too so it picks up the new conclusion.
- Existing open PRs will get the gate on their next push/rebase; dependabot PRs can be nudged with `@dependabot rebase`.