### PR TITLE
fix(kustomize): preserve pending tag bumps across automation PR runs

### DIFF
--- a/.github/workflows/deploy-update-images.yml
+++ b/.github/workflows/deploy-update-images.yml
@@ -41,6 +41,22 @@ jobs:
           curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
           sudo mv kustomize /usr/local/bin/
 
+      - name: Seed from existing automation PR branch
+        run: |
+          # peter-evans/create-pull-request rebuilds the PR branch from the base
+          # (main) plus the current working-tree diff on every run. Combined with
+          # CHANGED_ONLY, that drops tag bumps for services queued in a previous,
+          # not-yet-merged run. Restore the kustomization files from the automation
+          # branch first so those pending updates are carried forward, then this
+          # run's changed services are applied on top.
+          if git ls-remote --exit-code --heads origin automation-update-images >/dev/null 2>&1; then
+            echo "Automation branch exists; seeding kustomization tags to preserve pending (unmerged) updates"
+            git fetch --depth=1 origin automation-update-images
+            git checkout FETCH_HEAD -- deploy/k8s/applications/*/kustomization.yaml
+          else
+            echo "No existing automation branch; starting from ${GITHUB_REF_NAME:-main}"
+          fi
+
       - name: Update kustomize image tags (changed services)
         env:
           CHANGED_ONLY: true
@@ -76,7 +92,7 @@ jobs:
       - name: Summary
         run: |
           if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
-            echo "PR created/updated (branch chore/update-images)." >> $GITHUB_STEP_SUMMARY
+            echo "PR created/updated (branch automation-update-images)." >> $GITHUB_STEP_SUMMARY
           else
             echo "No changes detected; no PR action." >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
Keep CHANGED_ONLY, but seed the working tree from the existing
automation-update-images branch before applying updates. Otherwise
create-pull-request resets the branch to main + this run's diff, dropping
tag bumps for services queued in an earlier, not-yet-merged run.

Also fix the Summary step's stale branch name.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CQQDsC6GFPPjPXXWCqZ6oH