### PR TITLE
fix(tenancy): apply global query filters on get/exists by id

### DIFF
--- a/src/Services/CRM/Infrastructure/Repositories/BaseRepository.cs
+++ b/src/Services/CRM/Infrastructure/Repositories/BaseRepository.cs
@@ -33,7 +33,7 @@ public class BaseRepository<T> : IAsyncRepository<T> where T : class
     {
         // Interface expects non-null; callers should verify existence via ExistsAsync when needed.
         // Suppress possible null warning with null-forgiving operator.
-        return (await _dbContext.Set<T>().FindAsync(id))!;
+        return (await _dbContext.Set<T>().FirstOrDefaultAsync(e => EF.Property<Guid>(e, "Id") == id))!;
     }
 
     public async Task<IReadOnlyList<T>> ListAllAsync()
@@ -59,6 +59,6 @@ public class BaseRepository<T> : IAsyncRepository<T> where T : class
 
     public async Task<bool> ExistsAsync(Guid id)
     {
-        return await _dbContext.Set<T>().FindAsync(id) != null;
+        return await _dbContext.Set<T>().AnyAsync(e => EF.Property<Guid>(e, "Id") == id);
     }
 }

--- a/src/Services/Scheduling/Infrastructure/Repositories/BaseRepository.cs
+++ b/src/Services/Scheduling/Infrastructure/Repositories/BaseRepository.cs
@@ -33,7 +33,8 @@ public class BaseRepository<T> : IAsyncRepository<T> where T : class
     {
         // Interface expects non-null; callers should verify existence via ExistsAsync when needed.
         // Suppress possible null warning with null-forgiving operator.
-        return (await _dbContext.Set<T>().FindAsync(id))!;
+        // FirstOrDefaultAsync (unlike FindAsync) applies the global tenant query filter.
+        return (await _dbContext.Set<T>().FirstOrDefaultAsync(e => EF.Property<Guid>(e, "Id") == id))!;
     }
 
     public async Task<IReadOnlyList<T>> ListAllAsync()
@@ -49,6 +50,6 @@ public class BaseRepository<T> : IAsyncRepository<T> where T : class
 
     public async Task<bool> ExistsAsync(Guid id)
     {
-        return await _dbContext.Set<T>().FindAsync(id) != null;
+        return await _dbContext.Set<T>().AnyAsync(e => EF.Property<Guid>(e, "Id") == id);
     }
 }


### PR DESCRIPTION
## Bug

`BaseRepository` fetched entities using EF Core's `FindAsync(id)`. `FindAsync` looks entities up by primary key and, critically, **does not apply EF Core global query filters** — including the tenant filter. As a result, any get/update/delete-by-id operation could resolve an entity belonging to a different tenant, breaking cross-tenant data isolation (HIGH severity).

## Fix

Replace `FindAsync(id)` with filtered LINQ queries so the global query filter (tenant filter) is enforced:

- `GetByIdAsync` now uses `FirstOrDefaultAsync(e => EF.Property<Guid>(e, "Id") == id)`.
- `ExistsAsync` now uses `AnyAsync(e => EF.Property<Guid>(e, "Id") == id)`.

Applied identically in both services:

- `src/Services/CRM/Infrastructure/Repositories/BaseRepository.cs`
- `src/Services/Scheduling/Infrastructure/Repositories/BaseRepository.cs`

## Affected handlers

Any handler that resolves an entity by id through the base repository was exposed, e.g. `DeleteChild`, `UpdateChild` (CRM) and the equivalent get/update/delete-by-id handlers in Scheduling. These now correctly return "not found" / no-op across tenant boundaries instead of leaking or mutating another tenant's data.

## Already safe

List/search queries (`ListAllAsync` and query-side handlers built on `IQueryable`/`ToListAsync`) already went through the global query filter, so they were not affected by this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u)_