### PR TITLE
fix(errors): don't leak exception message on 500 responses

### DIFF
--- a/src/Services/CRM/Api/Middleware/ExceptionHandlerMiddleware.cs
+++ b/src/Services/CRM/Api/Middleware/ExceptionHandlerMiddleware.cs
@@ -211,7 +211,7 @@ public class ExceptionHandlerMiddleware
         {
             var errorResponse = new
             {
-                error = exception.Message,
+                error = (int)httpStatusCode >= 500 ? "An unexpected error occurred." : exception.Message,
                 status = (int)httpStatusCode,
                 traceId = traceId,
                 timestamp = errorDetails.Timestamp,

--- a/src/Services/Scheduling/Api/Middleware/ExceptionHandlerMiddleware.cs
+++ b/src/Services/Scheduling/Api/Middleware/ExceptionHandlerMiddleware.cs
@@ -135,7 +135,7 @@ public class ExceptionHandlerMiddleware
         {
             var errorResponse = new
             {
-                error = exception.Message,
+                error = (int)httpStatusCode >= 500 ? "An unexpected error occurred." : exception.Message,
                 status = (int)httpStatusCode,
                 traceId = traceId,
                 timestamp = errorDetails.Timestamp,


### PR DESCRIPTION
## Summary

Fixes an information-disclosure bug in the exception handler middleware. On unhandled 500-class errors, the fallback error response returned the raw `exception.Message` in the HTTP response body, leaking internal implementation details to clients.

## Fix

In the `if (result == string.Empty)` fallback block of both the CRM and Scheduling `ExceptionHandlerMiddleware`, the `error` field now returns a generic `"An unexpected error occurred."` message for 500-class status codes, while preserving the descriptive messages for 4xx client errors (NotFound / Conflict / BadRequest).

Full exception detail is still logged server-side; only the client-facing response is masked.

## Files changed

- `src/Services/CRM/Api/Middleware/ExceptionHandlerMiddleware.cs`
- `src/Services/Scheduling/Api/Middleware/ExceptionHandlerMiddleware.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u)_