### PR TITLE
fix(authz): enforce authenticated fallback policy in services

### DIFF
--- a/src/Services/CRM/Api/ConfigureServices.cs
+++ b/src/Services/CRM/Api/ConfigureServices.cs
@@ -83,7 +83,12 @@ public static class ConfigureServices
                         options.Audience = configuration["Auth0:Audience"];
                         options.RequireHttpsMetadata = authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
                     });
-        services.AddAuthorization();
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
+        });
 
         // Outgoing HTTP correlation propagation
         services.AddTransient<CorrelationIdPropagationHandler>();

--- a/src/Services/CRM/Api/Program.cs
+++ b/src/Services/CRM/Api/Program.cs
@@ -32,7 +32,7 @@ app.UseAuthorization();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<TenancyMiddleware>();
 
-app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/healthz").AllowAnonymous();
 
 // Map minimal API endpoints
 app.MapChildrenEndpoints();

--- a/src/Services/Scheduling/Api/ConfigureServices.cs
+++ b/src/Services/Scheduling/Api/ConfigureServices.cs
@@ -89,6 +89,13 @@ public static class ConfigureServices
                 };
             });
 
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
+        });
+
 
         var otel = services.AddOpenTelemetry();
 

--- a/src/Services/Scheduling/Api/Program.cs
+++ b/src/Services/Scheduling/Api/Program.cs
@@ -28,7 +28,7 @@ app.UseAuthorization();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<TenancyMiddleware>();
 
-app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/healthz").AllowAnonymous();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary

Neither the CRM nor the Scheduling service enforced authorization in-process; both relied solely on the Envoy gateway. This adds defense in depth by configuring a global authorization **FallbackPolicy** that requires an authenticated user in both services.

## Changes

- **CRM** (`src/Services/CRM/Api/ConfigureServices.cs`): replaced `services.AddAuthorization()` with a configuration that sets a `FallbackPolicy` requiring an authenticated user.
- **Scheduling** (`src/Services/Scheduling/Api/ConfigureServices.cs`): added the same `AddAuthorization` configuration (previously there was no `AddAuthorization` call at all) right after the JWT bearer registration.
- The fallback policy only calls `RequireAuthenticatedUser()` — no specific claim/scope is required, keeping the e2e mock-auth flow intact.

## Health check exemption

Health probes must remain reachable without authentication, so `/healthz` is exempted in both services:

- `src/Services/CRM/Api/Program.cs`: `app.MapHealthChecks("/healthz").AllowAnonymous();`
- `src/Services/Scheduling/Api/Program.cs`: same change.

This ensures infra/liveness probes continue to work while every other endpoint now requires an authenticated user by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u)_