### PR TITLE
fix(scheduling): only expose Swagger in Development

### DIFF
--- a/src/Services/Scheduling/Api/Program.cs
+++ b/src/Services/Scheduling/Api/Program.cs
@@ -16,7 +16,10 @@ builder.Logging.AddKdvManagerLogging(builder.Configuration, "scheduling-api");
 
 var app = builder.Build();
 
-app.UseSwagger();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+}
 
 app.UseRouting();
 


### PR DESCRIPTION
## Summary

The Scheduling API called `app.UseSwagger();` unconditionally in `src/Services/Scheduling/Api/Program.cs`, which exposed the API schema in production. This is an information-exposure issue.

This change gates `app.UseSwagger()` behind `app.Environment.IsDevelopment()`, so the OpenAPI schema is only served in the Development environment, matching how the CRM service handles it.

## Change

```csharp
if (app.Environment.IsDevelopment())
{
    app.UseSwagger();
}
```

There was no `app.UseSwaggerUI(...)` call to gate. No other behavior was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u)_