### PR TITLE
fix(web): drop unsafe-eval from CSP script-src

### DIFF
--- a/src/web/nginx/nginx.conf
+++ b/src/web/nginx/nginx.conf
@@ -29,7 +29,7 @@ server {
 
   # Content Security Policy (baseline; adjust as app evolves)
   # Note: Auth0 domain variables not available here at runtime; include explicit domains
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.auth0.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://kdvmanager.eu.auth0.com https://app.kdvmanager.nl https://api.kdvmanager.nl; frame-src 'self' https://kdvmanager.eu.auth0.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;" always;
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.auth0.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://kdvmanager.eu.auth0.com https://app.kdvmanager.nl https://api.kdvmanager.nl; frame-src 'self' https://kdvmanager.eu.auth0.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;" always;
 
   # Root application (SPA)
   location / {


### PR DESCRIPTION
## Summary

The `Content-Security-Policy` header in `src/web/nginx/nginx.conf` included both `'unsafe-inline'` and `'unsafe-eval'` in its `script-src` directive. Allowing `'unsafe-eval'` permits `eval()`, `new Function()`, and similar dynamic code execution, which significantly weakens the CSP's XSS mitigation.

Vite production builds do not require `'unsafe-eval'`, so it can be removed with no functional impact on the built SPA.

## Change

`script-src` in `src/web/nginx/nginx.conf` goes from:

```
script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.auth0.com
```

to:

```
script-src 'self' 'unsafe-inline' https://cdn.auth0.com
```

No other CSP directive (`style-src`, `connect-src`, `frame-src`, etc.) was modified. `src/web/nginx/nginx.e2e.conf` is a test-only config with no CSP header and was left untouched.

## Note

`'unsafe-inline'` was intentionally left in place for now. It is currently required by MUI/Emotion, which inject inline `<style>`/inline scripts at runtime. Removing it (e.g. via nonces/hashes) is tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u)_