### PR TITLE
fix(crm): derive AddChild tenant from tenancy context

### DIFF
--- a/src/Services/CRM/Application/Features/Children/Commands/AddChild/AddChildCommandHandler.cs
+++ b/src/Services/CRM/Application/Features/Children/Commands/AddChild/AddChildCommandHandler.cs
@@ -4,6 +4,7 @@ using KDVManager.Services.CRM.Application.Contracts.Persistence;
 using KDVManager.Services.CRM.Application.Contracts.Services;
 using KDVManager.Services.CRM.Domain.Entities;
 using KDVManager.Shared.Contracts.Events;
+using KDVManager.Shared.Contracts.Tenancy;
 using MassTransit;
 
 namespace KDVManager.Services.CRM.Application.Features.Children.Commands.AddChild;
@@ -13,15 +14,18 @@ public class AddChildCommandHandler
     private readonly IChildRepository _childRepository;
     private readonly IChildNumberSequenceService _childNumberSequenceService;
     private readonly IPublishEndpoint _publishEndpoint;
+    private readonly ITenancyContextAccessor _tenancyContextAccessor;
 
     public AddChildCommandHandler(
         IChildRepository childRepository,
         IChildNumberSequenceService childNumberSequenceService,
-        IPublishEndpoint publishEndpoint)
+        IPublishEndpoint publishEndpoint,
+        ITenancyContextAccessor tenancyContextAccessor)
     {
         _childRepository = childRepository;
         _childNumberSequenceService = childNumberSequenceService;
         _publishEndpoint = publishEndpoint;
+        _tenancyContextAccessor = tenancyContextAccessor;
     }
 
     public async Task<Guid> Handle(AddChildCommand request)
@@ -31,6 +35,8 @@ public class AddChildCommandHandler
 
         if (!validationResult.IsValid)
             throw new Exceptions.ValidationException(validationResult);
+
+        var tenantId = _tenancyContextAccessor.Current?.TenantId ?? throw new InvalidOperationException("Tenant context is required");
 
         // Get the next child number for this tenant
         var childNumber = await _childNumberSequenceService.GetNextChildNumberAsync();
@@ -43,7 +49,7 @@ public class AddChildCommandHandler
             DateOfBirth = (DateOnly)request.DateOfBirth!,
             CID = request.CID,
             ChildNumber = childNumber,
-            TenantId = Guid.Parse("7e520828-45e6-415f-b0ba-19d56a312f7f") // Default tenant ID for now
+            TenantId = tenantId
         };
 
         child = await _childRepository.AddAsync(child);


### PR DESCRIPTION
## Summary

Fixes a data-integrity bug in `AddChildCommandHandler` where every created child was assigned a hardcoded tenant GUID (`7e520828-45e6-415f-b0ba-19d56a312f7f`), ignoring the actual tenant of the request.

## Changes

- Inject `ITenancyContextAccessor` into `AddChildCommandHandler`.
- Resolve `TenantId` from the tenancy context: `_tenancyContextAccessor.Current?.TenantId ?? throw new InvalidOperationException("Tenant context is required")`.
- Assign the resolved `tenantId` to the new `Child` instead of the hardcoded GUID.

This mirrors the existing pattern in `AddGuardianCommandHandler`. `ITenancyContextAccessor` is already registered via `AddTenancy`, so no DI changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u)_