### PR TITLE
fix(ci): restore green build on main (NU1605 + pnpm ignored-builds)

### DIFF
--- a/src/Services/CRM/Infrastructure/Infrastructure.csproj
+++ b/src/Services/CRM/Infrastructure/Infrastructure.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="MassTransit" Version="8.5.10" />
   <PackageReference Include="OpenTelemetry" Version="1.15.3" />
   <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/src/Services/Scheduling/Infrastructure/Infrastructure.csproj
+++ b/src/Services/Scheduling/Infrastructure/Infrastructure.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="MassTransit" Version="8.5.10" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.10" />
   </ItemGroup>

--- a/src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj
+++ b/src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="MassTransit.Abstractions" Version="8.5.10" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="OpenTelemetry" Version="1.15.3" />

--- a/src/web/pnpm-workspace.yaml
+++ b/src/web/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   browser-tabs-lock: false
+  core-js-pure: false
   esbuild: true


### PR DESCRIPTION
Two independent, pre-existing build breakages on `main` currently fail CI for every open PR. Neither is caused by the security-fix PRs (#747–#752); they are unblocked once this merges.

## 1. .NET restore — NU1605 package downgrade

`dotnet restore` fails with:
```
error NU1605: Detected package downgrade:
Microsoft.Extensions.Options.ConfigurationExtensions from 10.0.9 to 10.0.5
```
Recent Dependabot bumps of the `Microsoft.Extensions.*` family to `10.0.9` introduced a transitive requirement of `Microsoft.Extensions.Options.ConfigurationExtensions >= 10.0.9` (via `OpenTelemetry` → `Microsoft.Extensions.Logging.Configuration`). Three infrastructure projects still pinned it directly at `10.0.5`, which NuGet flags as a downgrade and warnings-as-errors makes fatal.

Fix: bump the direct pin to `10.0.9` in:
- `src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj`
- `src/Services/CRM/Infrastructure/Infrastructure.csproj`
- `src/Services/Scheduling/Infrastructure/Infrastructure.csproj`

Confirmed: `BuildContainersForPR_Linux` now passes.

## 2. Web pnpm — ERR_PNPM_IGNORED_BUILDS

`pnpm install --frozen-lockfile` (web image, and therefore `e2e` and the web `Test`/`CI` checks) fails:
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: core-js-pure@3.49.0
```
pnpm v11 requires an explicit allow/deny decision for any dependency with a build script. `core-js-pure` only ships a funding/postinstall notice, so it is denied (`allowBuilds: core-js-pure: false`) — no script executes. Mirrors the existing `browser-tabs-lock: false` entry.

Fix: `src/web/pnpm-workspace.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5NAZTk3d5kRmRwghTk23u