### PR TITLE
fix(e2e): compute 'today' in the browser timezone in schedule overview spec

### DIFF
--- a/tests/e2e/specs/schedule-overview.spec.ts
+++ b/tests/e2e/specs/schedule-overview.spec.ts
@@ -28,6 +28,15 @@ function addDays(iso: string, days: number): string {
   return isoDate(new Date(y, m - 1, d + days));
 }
 
+/**
+ * Today's YYYY-MM-DD in the browser timezone (Europe/Amsterdam, see
+ * playwright.config.ts). Node runs in the runner's timezone (UTC on CI),
+ * which is a day behind Amsterdam between 22:00 and midnight UTC.
+ */
+function todayInAppTimezone(): string {
+  return new Intl.DateTimeFormat("sv-SE", { timeZone: "Europe/Amsterdam" }).format(new Date());
+}
+
 /** First Wednesday of the current month (a fixed, scheduled weekday). */
 function firstWednesdayOfCurrentMonth(): string {
   const now = new Date();
@@ -137,7 +146,7 @@ test.describe("schedule overview", () => {
   test("date navigation updates the date URL param", async ({ page }) => {
     // Start far away from today so next/previous never lands on today
     // (the "Vandaag" button is disabled when today is selected).
-    const start = addDays(isoDate(new Date()), 30);
+    const start = addDays(todayInAppTimezone(), 30);
     await gotoApp(page, `/schedule?date=${start}`);
 
     // The next/previous IconButtons have no accessible name, and MUI only emits
@@ -163,7 +172,7 @@ test.describe("schedule overview", () => {
     await expect(page).toHaveURL(new RegExp(`[?&]date=${addDays(start, -1)}`));
 
     await page.getByRole("button", { name: "Vandaag" }).click();
-    await expect(page).toHaveURL(new RegExp(`[?&]date=${isoDate(new Date())}`));
+    await expect(page).toHaveURL(new RegExp(`[?&]date=${todayInAppTimezone()}`));
   });
 
   test("shows the closure indication on a closed day", async ({ page }) => {


### PR DESCRIPTION
## Problem

The `date navigation updates the date URL param` test in `schedule-overview.spec.ts` fails on main between 22:00 and midnight UTC:

```
Expected pattern: /[?&]date=2026-07-02/
Received string:  "http://localhost:9090/schedule?date=2026-07-03"
```

`playwright.config.ts` pins the browser timezone to `Europe/Amsterdam`, but the spec computes "today" with `new Date()` in the Node/runner timezone (UTC on CI). In that late-evening window the two disagree by one day, so the "Vandaag" assertion fails. Seen on the e2e run for 6eb0a9a (22:14 UTC).

## Fix

Add a `todayInAppTimezone()` helper that formats today via `Intl.DateTimeFormat` with `timeZone: "Europe/Amsterdam"`, and use it for the test's start date and the "Vandaag" assertion. Other `new Date()` uses in the specs are timezone-insensitive (date of birth years in the past, year/month pairs).