### PR TITLE
fix(e2e): gate stack startup on postgres health and migrator completion

### DIFF
--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -8,6 +8,9 @@
 #  - Envoy uses envoy.e2e.yaml (JWT validation against mock-auth)
 #  - web is built against mock-auth and served with a CSP-free nginx config
 #  - postgres has no volume, so every run starts from a clean database
+#  - startup is ordered: migrators wait for postgres to be healthy, APIs wait
+#    for their migrator to finish (on a cold start the migrator otherwise races
+#    postgres and the API crashes on the missing database)
 services:
   mock-auth:
     image: node:24-alpine
@@ -31,6 +34,11 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_USER=sammy
       - POSTGRES_PASSWORD=shark
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sammy"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
 
   rabbitmq:
     environment:
@@ -53,6 +61,9 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionStrings__KDVManagerCRMConnectionString=Server=postgres; port=5432; database=KDVManagerCRMDB; User ID=sammy; password=shark; pooling=true
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   crm-api:
     environment:
@@ -63,14 +74,22 @@ services:
       - Auth0__Authority=http://mock-auth:5300
       - Auth0__Audience=https://api.kdvmanager.nl/
     depends_on:
-      - postgres
-      - rabbitmq
-      - mock-auth
+      postgres:
+        condition: service_healthy
+      crm-migrator:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_started
+      mock-auth:
+        condition: service_started
 
   scheduling-migrator:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionStrings__KDVManagerSchedulingConnectionString=Server=postgres; port=5432; database=KDVManagerSchedulingDB; User ID=sammy; password=shark; pooling=true
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   scheduling-api:
     environment:
@@ -81,6 +100,11 @@ services:
       - Auth0__Authority=http://mock-auth:5300
       - Auth0__Audience=https://api.kdvmanager.nl/
     depends_on:
-      - postgres
-      - rabbitmq
-      - mock-auth
+      postgres:
+        condition: service_healthy
+      scheduling-migrator:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_started
+      mock-auth:
+        condition: service_started


### PR DESCRIPTION
## Problem

The e2e job is flaky on cold starts, e.g. [run 28625124876](https://github.com/LuukLabs/KDVManager/actions/runs/28625124876) on #754: Playwright's global-setup times out waiting for `scheduling-api`.

The stack logs show the actual sequence:

1. `scheduling-migrator` starts before postgres is accepting connections, gets `Connection refused` (`Npgsql.NpgsqlException: Failed to connect to 172.18.0.5:5432`), and exits without applying migrations.
2. `scheduling-api` starts anyway (bare `depends_on` only orders container start). Its `ScheduleStatusSyncHostedService` immediately queries the database, hits `3D000: database "KDVManagerSchedulingDB" does not exist`, and the unhandled BackgroundService exception stops the host.
3. With scheduling-api dead, global-setup times out after 4 minutes.

`crm-migrator` won the same race by luck in this run.

## Fix

In the e2e compose overlay:

- Add a `pg_isready` healthcheck to postgres.
- Migrators wait for postgres with `condition: service_healthy`.
- Each API waits for its migrator with `condition: service_completed_successfully` (plus postgres healthy).

Verified the merged config with `docker compose -f docker-compose.yml -f docker-compose.e2e.yml config` — the conditions resolve as intended on all four services.

Production/dev compose behavior is untouched; only `docker-compose.e2e.yml` changes.