### PR TITLE
Harden multi-tenancy to prevent cross-tenant issues

### DIFF
--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -1,0 +1,61 @@
+# Multi-Tenancy Strategy & Isolation
+
+KDVManager is a **shared-database, shared-schema** multi-tenant system. Every
+tenant-owned row carries a non-nullable `TenantId` (GUID) discriminator column.
+There is no per-tenant database or schema, and there is no database-level Row
+Level Security — isolation is enforced entirely in the application layer.
+
+## How a tenant is identified
+
+1. Auth0 mints an access token containing the custom claim
+   `https://kdvmanager.nl/tenant` (see `TenancyClaimTypes.TenantId`).
+2. The Envoy gateway validates the JWT signature/issuer/audience and forwards it.
+3. Each service **also** validates the JWT (`AddJwtBearer`) — it does not trust
+   the gateway blindly.
+4. `TenancyMiddleware` runs `JwtTenancyResolver`, which reads the tenant claim and
+   sets the ambient `ITenancyContextAccessor.Current` for the request scope.
+
+Middleware order is `UseAuthentication → UseAuthorization → TenancyMiddleware`,
+so claims are populated before the tenant is resolved.
+
+## How isolation is enforced
+
+- **EF Core global query filters.** Every `IMustHaveTenant` entity has
+  `HasQueryFilter(e => e.TenantId == accessor.Current!.TenantId)`. Every read is
+  transparently scoped to the current tenant.
+- **`SaveChanges` stamping.** Both `ApplicationDbContext`s override `SaveChanges`
+  / `SaveChangesAsync` to stamp `TenantId` from the ambient tenant onto every
+  **added or modified** tenant-owned entity.
+- **Fail-closed accessor.** `TenancyContextAccessor.Current` *throws*
+  `TenantRequiredException` when no tenant is set, so any query issued without a
+  resolved tenant fails hard instead of leaking cross-tenant rows.
+- **Cross-service propagation.** Tenant flows over RabbitMQ as the MassTransit
+  message header `TenantId` (publish/send filters set it; the consume filter
+  restores it into the ambient context).
+
+## Hardening applied (this change)
+
+| # | Area | Change |
+|---|------|--------|
+| 1 | Create handlers | Removed the hard-coded default tenant GUID (`7e520828-…`) from `AddChild` (CRM) and `AddGroup` / `AddTimeSlot` / `AddSchedule` (Scheduling). They now resolve the tenant from `ITenancyContextAccessor`, and `AddSchedule` also stamps child `ScheduleRule`s explicitly. |
+| 2 | AuthN gate | Added a fallback authorization policy (`RequireAuthenticatedUser`) to both APIs so a request reaching a service directly (gateway bypass / SSRF) is rejected with 401 instead of running anonymously. Health checks and OpenAPI are explicitly `AllowAnonymous`. |
+| 3 | Tenant gate | `TenancyMiddleware` now returns **403** when an *authenticated* request carries no tenant claim, rather than relying solely on a downstream 500. |
+| 4 | Persistence | Both DbContexts now also override the **synchronous** `SaveChanges`, and Scheduling now re-stamps on **Modified** (previously Added only) — closing the gap where a wrongly-constructed entity could persist under the wrong tenant. |
+| 5 | Message bus | The consume filter uses `Guid.TryParse` and fails closed on a malformed `TenantId` header instead of throwing; per-message tenant logging downgraded from `Information` to `Debug`. |
+| 6 | Hygiene | Centralised the tenant claim type in `TenancyClaimTypes` (was a magic string). |
+
+## Known residual risks / recommendations
+
+- **No DB backstop.** Isolation is application-only. Any future raw SQL,
+  `ExecuteUpdate/Delete`, Dapper, or `IgnoreQueryFilters()` usage bypasses it.
+  Consider PostgreSQL Row Level Security keyed on a `SET app.tenant_id` session
+  variable as a second layer, and add `TenantId` indexes (only `Child`,
+  `ChildNumberSequence`, `EndMarkSettings` currently have one) for performance.
+- **Broker trust.** Any actor able to publish directly to RabbitMQ with a chosen
+  `TenantId` header can impersonate a tenant. Restrict broker access.
+- **Cross-entity references.** `AddSchedule` does not verify that `GroupId` /
+  `ChildId` belong to the caller's tenant. Query filters prevent *reading* another
+  tenant's data, but a dangling cross-tenant reference can be stored. Consider
+  validating referenced ids against tenant-scoped repositories.
+- **The single intentional bypass** is `ScheduleStatusService.SyncAllChildrenStatusAsync`
+  (a background hosted service) — verify it is never reachable from a request path.

--- a/docs/proposals/multi-tenancy-cqrs.md
+++ b/docs/proposals/multi-tenancy-cqrs.md
@@ -1,0 +1,340 @@
+# Proposal: Multi-Tenancy for a CQRS .NET SaaS
+
+**Status:** Draft for review
+**Applies to:** CRM + Scheduling services, Shared kernel
+**Author:** Architecture review
+
+This proposal describes best-practice multi-tenancy for KDVManager given its
+CQRS-style, clean-architecture .NET microservices, and lays out a concrete,
+phased plan to get there. It builds on the isolation hardening already applied
+(see `docs/multi-tenancy.md`).
+
+---
+
+## 1. Where we are today
+
+| Aspect | Current state |
+|---|---|
+| Isolation model | Shared database, shared schema, `TenantId` discriminator column |
+| Tenant identity | Auth0 access-token claim `https://kdvmanager.nl/tenant` |
+| Enforcement | EF Core global query filters + `SaveChanges` stamping + fail-closed accessor |
+| CQRS style | Hand-rolled command/query handlers invoked **directly** from endpoints/controllers (no MediatR, no pipeline) |
+| Validation | FluentValidation instantiated inside each handler |
+| Messaging | MassTransit/RabbitMQ, **direct `Publish`** (no transactional outbox), tenant carried as `TenantId` header |
+| Tenant lifecycle | None — a tenant is just a GUID; no registry, onboarding, plan, or config |
+| Tenant context | Scoped DI accessor; the background sync job mutates it in a loop |
+
+The foundation is sound. The gaps below are what separate "works" from
+"enterprise SaaS-grade."
+
+---
+
+## 2. Guiding principles
+
+1. **Tenancy is a cross-cutting concern, not handler logic.** It must be
+   enforced in one place (a pipeline), not re-implemented per handler.
+2. **Defense in depth.** No single mechanism is trusted. Claim → pipeline guard
+   → EF query filter → database RLS → automated isolation tests.
+3. **Fail closed, always.** Absence of a tenant is an error, never "all tenants."
+4. **Cross-tenant access is explicit and audited.** The only way to touch more
+   than one tenant is to *deliberately* open a privileged scope.
+5. **The write model owns the tenant; the read model filters by it.** This is
+   the CQRS-specific expression of the discriminator pattern.
+6. **Isolation model is a per-tenant runtime decision, not a code assumption.**
+   Design so a tenant can graduate from pooled → siloed without rewrites.
+
+---
+
+## 3. Data isolation model & tenancy tiers
+
+Three canonical SaaS isolation models (AWS SaaS Lens terminology):
+
+| Model | Isolation | Cost / density | Ops | Fits |
+|---|---|---|---|---|
+| **Pooled** — shared DB + schema + `TenantId` | Logical (app/RLS) | Highest density, cheapest | Simple, single migration | Most tenants |
+| **Bridge** — shared DB, schema-per-tenant | Stronger | Medium | Migration fan-out | Mid/large tenants |
+| **Siloed** — DB-per-tenant | Physical | Lowest density | Provisioning + migration per tenant | Enterprise / regulated |
+
+**Recommendation:** Stay **pooled** as the default (it fits a childcare-SaaS
+economics profile), but introduce the seams now so a specific tenant can be
+moved to **siloed** later without touching application code:
+
+- Resolve the **connection string per tenant** from the tenant registry
+  (§8) instead of a single `appsettings` value. For pooled tenants they all
+  resolve to the same connection; a siloed tenant resolves to its own. The
+  `DbContext` factory reads the resolved connection from the tenant context.
+- Keep the `TenantId` column even in siloed DBs (belt-and-suspenders + trivial
+  migration path back to pooled).
+
+This "pluggable isolation" is the single most important enterprise design seam,
+and it is cheap to add before there is data to migrate.
+
+---
+
+## 4. Tenant context: ambient + explicit scope
+
+Replace the mutable scoped accessor with an **immutable ambient context** backed
+by `AsyncLocal`, plus an **explicit scope** for the rare cross-tenant path.
+
+```csharp
+public interface ITenantContext
+{
+    Guid TenantId { get; }
+    string? ConnectionString { get; }   // enables siloed tenants (§3)
+    TenantTier Tier { get; }            // from the registry (§8)
+}
+
+public interface ITenantContextAccessor
+{
+    ITenantContext? Current { get; }               // throws if required and unset
+    IDisposable BeginScope(ITenantContext context); // AsyncLocal push/pop
+}
+```
+
+- HTTP: middleware resolves the tenant once and calls `BeginScope`.
+- Messaging: the consume filter calls `BeginScope` from the `TenantId` header.
+- **Background/batch jobs** (e.g. `ScheduleStatusSyncHostedService`): iterate
+  tenants and `using (accessor.BeginScope(tenant))` per iteration — no shared
+  mutation, correct under concurrency, auto-restored on dispose. This directly
+  fixes the current "mutate `Current` in a loop" smell.
+
+`AsyncLocal` (not scoped DI) is the correct primitive because it flows across
+`await`, `Task.Run`, and parallel loops, and it makes the scope lifetime
+explicit rather than tied to a DI container scope.
+
+---
+
+## 5. CQRS-specific patterns
+
+### 5.1 Introduce a mediator/pipeline (the enabling change)
+
+Today handlers are called directly, so every cross-cutting rule must be copied
+into every handler. Adopt **MediatR** (or a lightweight in-house
+`ICommandHandler`/behavior pipeline if you want zero dependencies). This gives a
+single interception point for tenancy, validation, logging, transactions, and
+outbox.
+
+```
+Request → [TenantGuardBehavior] → [ValidationBehavior] → [UnitOfWork/OutboxBehavior] → Handler
+```
+
+### 5.2 Tenant guard behavior (both commands and queries)
+
+```csharp
+public sealed class TenantGuardBehavior<TReq, TRes> : IPipelineBehavior<TReq, TRes>
+{
+    private readonly ITenantContextAccessor _tenant;
+    public async Task<TRes> Handle(TReq request, RequestHandlerDelegate<TRes> next, CancellationToken ct)
+    {
+        // Fail closed: no ambient tenant ⇒ no tenant-scoped work permitted,
+        // unless the request is explicitly marked cross-tenant (§5.4).
+        if (request is not ICrossTenantRequest && _tenant.Current is null)
+            throw new TenantRequiredException();
+        return await next();
+    }
+}
+```
+
+Handlers stop caring about tenancy entirely — they never read or set `TenantId`.
+
+### 5.3 Write side owns the tenant
+
+- Commands and DTOs **never** contain a `TenantId` (prevents over-posting).
+- `TenantId` is stamped exactly once, in `SaveChanges` (already done) — remove
+  every hand-set `TenantId` from handlers (the hard-coded GUIDs are gone; the
+  goal state is handlers that don't mention `TenantId` at all).
+- **Validate cross-entity references against the tenant.** A command that
+  references another aggregate (e.g. `AddSchedule` → `GroupId`, `ChildId`) must
+  verify those ids resolve *inside the current tenant* via tenant-scoped
+  repositories. Query filters stop cross-tenant *reads* but not the storing of a
+  dangling cross-tenant reference.
+
+### 5.4 Read side filters by tenant
+
+- Global query filters remain the default (already in place).
+- **`IgnoreQueryFilters()` is banned** except in a small, reviewed allow-list.
+  Enforce with an architecture test (§11) that fails the build on new usages.
+- Cross-tenant reads (admin dashboards, platform reports) use an explicit
+  `ICrossTenantRequest` marker and run inside `BeginScope`-per-tenant or a
+  dedicated privileged read model — never by silently dropping the filter.
+
+### 5.5 Read models / projections
+
+For expensive cross-aggregate queries (daily overview, print schedules),
+consider **tenant-scoped denormalised read models** updated from domain events.
+Each projection row carries `TenantId` and is filtered identically. This keeps
+the query side fast and the isolation story uniform.
+
+---
+
+## 6. Defense in depth — database Row-Level Security (RLS)
+
+Application-only isolation means one raw-SQL mistake = cross-tenant leak. Add a
+**PostgreSQL RLS backstop** so the database refuses cross-tenant rows even if the
+EF filter is bypassed:
+
+```sql
+ALTER TABLE "Children" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "Children"
+  USING ("TenantId" = current_setting('app.tenant_id')::uuid);
+```
+
+Set the session variable per unit of work via a `DbConnection` interceptor:
+
+```csharp
+// SaveChanges/command open: SET app.tenant_id = @tenant  (or SET LOCAL in a tx)
+```
+
+RLS is transparent to EF, costs little on an indexed `TenantId`, and turns a
+class of application bugs into "returns nothing" instead of "leaks everything."
+Pair it with the index recommendations below.
+
+**Indexing:** most tables filter by `TenantId` on every query but lack an index
+on it (only `Child`, `ChildNumberSequence`, `EndMarkSettings` have one today).
+Add `TenantId` as the **leading column** of the relevant indexes (e.g.
+`(TenantId, StartDate)` on `Schedule`) — this serves both the query filter and
+RLS.
+
+---
+
+## 7. Reliability: transactional outbox
+
+Direct `IPublishEndpoint.Publish` after `SaveChanges` can lose events (DB commits,
+broker publish fails) or emit phantom events (publish succeeds, commit rolls
+back). In a multi-tenant system this produces **cross-service tenant drift**
+(e.g. a child exists in CRM but never in Scheduling).
+
+Adopt the **MassTransit EF Core outbox** so the event is written in the same
+transaction as the data and delivered exactly-once:
+
+```csharp
+x.AddEntityFrameworkOutbox<ApplicationDbContext>(o =>
+{
+    o.UsePostgres();
+    o.UseBusOutbox();
+});
+```
+
+The tenant `TenantId` header is then set by the existing publish filter at
+delivery time — keep that. This makes tenant propagation across services
+reliable, which is the whole point of the message header.
+
+---
+
+## 8. Tenant registry & lifecycle (the missing enterprise piece)
+
+Today a tenant is an opaque GUID minted by Auth0. Enterprise SaaS needs a
+**tenant catalog** as a first-class concept:
+
+- **Registry** (small dedicated service or a table owned by an `Admin`/`Identity`
+  service): `TenantId`, name, status (`Provisioning`/`Active`/`Suspended`/`Offboarding`),
+  tier/plan, isolation mode + connection string, region, feature flags, limits.
+- **Onboarding workflow:** create tenant → provision storage (no-op for pooled;
+  create DB + migrate for siloed) → seed defaults (groups, time slots) → create
+  the Auth0 org/first admin → activate. Model it as a saga so it is resumable.
+- **Offboarding:** suspend → export → hard-delete or crypto-shred. GDPR-relevant
+  for childcare data.
+- **Resolution:** middleware resolves the claim → looks up the registry →
+  materialises the full `ITenantContext` (tier, connection, flags). A
+  **suspended** tenant is rejected here, centrally.
+
+The registry is what lets you charge, throttle, feature-gate, and physically
+isolate tenants without scattering `if (tenant == …)` through the code.
+
+---
+
+## 9. Cross-cutting concerns
+
+- **Caching:** every cache key **must** include `TenantId`. A tenant-agnostic key
+  is a cross-tenant leak. Provide an `ITenantCacheKey` helper and forbid raw keys.
+- **Noisy neighbour / rate limiting:** apply per-tenant rate limits and quotas
+  (ASP.NET rate limiting middleware partitioned by `TenantId`) using limits from
+  the registry tier. Prevents one tenant starving others in a pooled model.
+- **Feature flags / config:** resolve per-tenant from the registry, not global
+  config. Enables plan-based gating and staged rollouts.
+- **Migrations:** pooled = one migration. When siloed tenants exist, run
+  migrations as a fan-out step in the deploy pipeline over the registry's active
+  siloed connections. Keep migrations tenant-agnostic (no data assumptions).
+- **Background jobs:** always tenant-scoped via `BeginScope` (§4); never assume a
+  single tenant.
+
+---
+
+## 10. Observability & audit
+
+- Tenant is already tagged on traces/logs — keep it, and ensure `TenantId` is a
+  **low-cardinality dimension** you can filter dashboards/SLOs by per tenant.
+- Add a **tenant audit log** for privileged/cross-tenant operations (who ran a
+  cross-tenant query, tenant lifecycle changes). Enterprise buyers expect this.
+- Avoid putting **PII** (names, DOB) in logs/traces; `TenantId` is fine, child
+  data is not.
+
+---
+
+## 11. Testing tenant isolation (make leaks a build failure)
+
+- **Isolation integration tests:** seed data for tenant A and B; assert every
+  query/command as B can never see or mutate A's rows. Run against a real
+  Postgres (Testcontainers) so RLS + query filters are both exercised.
+- **Architecture tests** (NetArchTest / Roslyn analyzer):
+  - No `IgnoreQueryFilters()` outside the reviewed allow-list.
+  - No command/DTO exposes a settable `TenantId`.
+  - No raw SQL (`FromSqlRaw`/`ExecuteSqlRaw`) without a tenant predicate.
+- **Contract test** on the message bus: a consumed message with no/invalid
+  `TenantId` header fails closed (never processes under a default tenant).
+
+---
+
+## 12. Target architecture (summary)
+
+```
+                    Auth0 (org + tenant claim)
+                             │  JWT
+                    ┌────────▼─────────┐
+                    │  Envoy gateway   │  (validates JWT)
+                    └────────┬─────────┘
+        ┌────────────────────┼─────────────────────┐
+        ▼                    ▼                       ▼
+   CRM service         Scheduling service      (future services)
+   ─────────────       ──────────────────
+   Middleware: resolve claim → Tenant Registry lookup → BeginScope(ITenantContext)
+   MediatR pipeline:  TenantGuard → Validation → UnitOfWork+Outbox → Handler
+   EF Core:           global query filters (read) + SaveChanges stamp (write)
+   Postgres:          RLS policy on app.tenant_id  ← defense-in-depth backstop
+   Messaging:         EF outbox → RabbitMQ, TenantId header → consume BeginScope
+        │
+        └── Tenant Registry (catalog, tier, connection, flags, lifecycle saga)
+```
+
+---
+
+## 13. Phased roadmap
+
+| Phase | Goal | Work | Risk |
+|---|---|---|---|
+| **0 — done** | Close known leaks | Remove hard-coded tenant GUIDs, fallback auth policy, fail-closed middleware, sync `SaveChanges` guard | Shipped |
+| **1** | Enforce tenancy in one place | Introduce MediatR + `TenantGuardBehavior` + `ValidationBehavior`; handlers stop touching `TenantId`; add cross-entity reference validation | Medium (refactor) |
+| **2** | Database backstop | Add `TenantId` indexes (leading col) + Postgres RLS + connection interceptor; architecture tests banning filter bypass | Low–Medium |
+| **3** | Reliable propagation | MassTransit EF outbox in both services | Low |
+| **4** | Ambient context | `AsyncLocal` `ITenantContext` + explicit `BeginScope`; fix background job + consume filter | Low |
+| **5** | Tenant registry | Registry + resolution + onboarding/offboarding saga; suspended-tenant rejection | High (new capability) |
+| **6** | SaaS operations | Per-tenant rate limits, tenant-scoped cache keys, feature flags, pluggable connection for siloed tenants | Medium |
+
+Phases 1–4 harden what exists and are mostly internal refactors. Phases 5–6 add
+the SaaS business capabilities (billing-tier gating, onboarding, physical
+isolation) that enterprise customers require.
+
+---
+
+## 14. Key trade-offs
+
+- **Pooled vs siloed:** pooled is cheaper and simpler; siloed is what regulated
+  or large enterprise tenants demand. The registry + pluggable connection lets
+  you offer *both* without a fork.
+- **MediatR dependency:** adds a library and indirection, but removing duplicated
+  cross-cutting logic (and guaranteeing it runs) is worth it in a system where a
+  missed guard is a data breach. A hand-rolled decorator pipeline is an
+  acceptable zero-dependency alternative.
+- **RLS:** small runtime cost and an extra migration discipline, in exchange for
+  turning a whole bug class from "silent leak" into "returns nothing." Strongly
+  recommended for childcare PII.

--- a/src/Services/CRM/Api/ConfigureServices.cs
+++ b/src/Services/CRM/Api/ConfigureServices.cs
@@ -1,5 +1,6 @@
 using MassTransit.Logging;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.OpenApi;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -83,7 +84,15 @@ public static class ConfigureServices
                         options.Audience = configuration["Auth0:Audience"];
                         options.RequireHttpsMetadata = authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
                     });
-        services.AddAuthorization();
+        // Defense-in-depth: require an authenticated principal by default so that a
+        // request reaching the service directly (bypassing the gateway) is rejected
+        // unless an endpoint explicitly opts out via AllowAnonymous.
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
+        });
 
         // Outgoing HTTP correlation propagation
         services.AddTransient<CorrelationIdPropagationHandler>();

--- a/src/Services/CRM/Api/Program.cs
+++ b/src/Services/CRM/Api/Program.cs
@@ -19,7 +19,7 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.MapOpenApi().AllowAnonymous();
 }
 
 app.UseRouting();
@@ -32,7 +32,7 @@ app.UseAuthorization();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<TenancyMiddleware>();
 
-app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/healthz").AllowAnonymous();
 
 // Map minimal API endpoints
 app.MapChildrenEndpoints();

--- a/src/Services/CRM/Application/Features/Children/Commands/AddChild/AddChildCommandHandler.cs
+++ b/src/Services/CRM/Application/Features/Children/Commands/AddChild/AddChildCommandHandler.cs
@@ -4,6 +4,7 @@ using KDVManager.Services.CRM.Application.Contracts.Persistence;
 using KDVManager.Services.CRM.Application.Contracts.Services;
 using KDVManager.Services.CRM.Domain.Entities;
 using KDVManager.Shared.Contracts.Events;
+using KDVManager.Shared.Contracts.Tenancy;
 using MassTransit;
 
 namespace KDVManager.Services.CRM.Application.Features.Children.Commands.AddChild;
@@ -13,15 +14,18 @@ public class AddChildCommandHandler
     private readonly IChildRepository _childRepository;
     private readonly IChildNumberSequenceService _childNumberSequenceService;
     private readonly IPublishEndpoint _publishEndpoint;
+    private readonly ITenancyContextAccessor _tenancyContextAccessor;
 
     public AddChildCommandHandler(
         IChildRepository childRepository,
         IChildNumberSequenceService childNumberSequenceService,
-        IPublishEndpoint publishEndpoint)
+        IPublishEndpoint publishEndpoint,
+        ITenancyContextAccessor tenancyContextAccessor)
     {
         _childRepository = childRepository;
         _childNumberSequenceService = childNumberSequenceService;
         _publishEndpoint = publishEndpoint;
+        _tenancyContextAccessor = tenancyContextAccessor;
     }
 
     public async Task<Guid> Handle(AddChildCommand request)
@@ -43,7 +47,7 @@ public class AddChildCommandHandler
             DateOfBirth = (DateOnly)request.DateOfBirth!,
             CID = request.CID,
             ChildNumber = childNumber,
-            TenantId = Guid.Parse("7e520828-45e6-415f-b0ba-19d56a312f7f") // Default tenant ID for now
+            TenantId = _tenancyContextAccessor.Current!.TenantId
         };
 
         child = await _childRepository.AddAsync(child);

--- a/src/Services/CRM/Infrastructure/ApplicationDbContext.cs
+++ b/src/Services/CRM/Infrastructure/ApplicationDbContext.cs
@@ -61,17 +61,41 @@ public class ApplicationDbContext : DbContext
 
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
     {
+        ApplyTenantToTrackedEntities();
+        var result = await base.SaveChangesAsync(cancellationToken);
+        return result;
+    }
+
+    public override int SaveChanges()
+    {
+        ApplyTenantToTrackedEntities();
+        return base.SaveChanges();
+    }
+
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        ApplyTenantToTrackedEntities();
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    /// <summary>
+    /// Stamps the current tenant onto every added or modified tenant-owned entity.
+    /// Re-stamping on Modified prevents a tenant identifier from being reassigned
+    /// via an update and guarantees isolation even if an entity was constructed
+    /// without an explicit TenantId.
+    /// </summary>
+    private void ApplyTenantToTrackedEntities()
+    {
+        var tenantId = _tenancyContextAccessor.Current!.TenantId;
         foreach (var entry in ChangeTracker.Entries<IMustHaveTenant>())
         {
             switch (entry.State)
             {
                 case EntityState.Added:
                 case EntityState.Modified:
-                    entry.Entity.TenantId = _tenancyContextAccessor.Current!.TenantId;
+                    entry.Entity.TenantId = tenantId;
                     break;
             }
         }
-        var result = await base.SaveChangesAsync(cancellationToken);
-        return result;
     }
 }

--- a/src/Services/Scheduling/Api/ConfigureServices.cs
+++ b/src/Services/Scheduling/Api/ConfigureServices.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.OpenApi;
 using System.Text.Json.Nodes;
 using OpenTelemetry.Resources;
@@ -88,6 +89,16 @@ public static class ConfigureServices
                     }
                 };
             });
+
+        // Defense-in-depth: require an authenticated principal by default so that a
+        // request reaching the service directly (bypassing the gateway) is rejected
+        // unless an endpoint explicitly opts out via AllowAnonymous.
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
+        });
 
 
         var otel = services.AddOpenTelemetry();

--- a/src/Services/Scheduling/Api/Program.cs
+++ b/src/Services/Scheduling/Api/Program.cs
@@ -31,7 +31,7 @@ app.UseAuthorization();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<TenancyMiddleware>();
 
-app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/healthz").AllowAnonymous();
 
 app.MapControllers();
 

--- a/src/Services/Scheduling/Application/Features/Groups/Commands/AddGroup/AddGroupCommandHandler.cs
+++ b/src/Services/Scheduling/Application/Features/Groups/Commands/AddGroup/AddGroupCommandHandler.cs
@@ -2,16 +2,19 @@
 using System.Threading.Tasks;
 using KDVManager.Services.Scheduling.Application.Contracts.Persistence;
 using KDVManager.Services.Scheduling.Domain.Entities;
+using KDVManager.Shared.Contracts.Tenancy;
 
 namespace KDVManager.Services.Scheduling.Application.Features.Groups.Commands.AddGroup;
 
 public class AddGroupCommandHandler
 {
     private readonly IGroupRepository _groupRepository;
+    private readonly ITenancyContextAccessor _tenancyContextAccessor;
 
-    public AddGroupCommandHandler(IGroupRepository groupRepository)
+    public AddGroupCommandHandler(IGroupRepository groupRepository, ITenancyContextAccessor tenancyContextAccessor)
     {
         _groupRepository = groupRepository;
+        _tenancyContextAccessor = tenancyContextAccessor;
     }
 
     public async Task<Guid> Handle(AddGroupCommand request)
@@ -26,7 +29,7 @@ public class AddGroupCommandHandler
         {
             Id = Guid.NewGuid(),
             Name = request.Name,
-            TenantId = Guid.Parse("7e520828-45e6-415f-b0ba-19d56a312f7f") // Default tenant ID for now
+            TenantId = _tenancyContextAccessor.Current!.TenantId
         };
 
         group = await _groupRepository.AddAsync(group);

--- a/src/Services/Scheduling/Application/Features/Schedules/Commands/AddSchedule/AddScheduleCommandHandler.cs
+++ b/src/Services/Scheduling/Application/Features/Schedules/Commands/AddSchedule/AddScheduleCommandHandler.cs
@@ -7,6 +7,7 @@ using KDVManager.Services.Scheduling.Domain.Entities;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using KDVManager.Services.Scheduling.Application.Services;
+using KDVManager.Shared.Contracts.Tenancy;
 
 namespace KDVManager.Services.Scheduling.Application.Features.Schedules.Commands.AddSchedule;
 
@@ -16,17 +17,20 @@ public class AddScheduleCommandHandler
     private readonly ITimeSlotRepository _timeSlotRepository;
     private readonly IScheduleTimelineService _timelineService;
     private readonly IScheduleStatusService _scheduleStatusService;
+    private readonly ITenancyContextAccessor _tenancyContextAccessor;
 
     public AddScheduleCommandHandler(
         IScheduleRepository scheduleRepository,
         ITimeSlotRepository timeSlotRepository,
         IScheduleTimelineService timelineService,
-        IScheduleStatusService scheduleStatusService)
+        IScheduleStatusService scheduleStatusService,
+        ITenancyContextAccessor tenancyContextAccessor)
     {
         _scheduleRepository = scheduleRepository;
         _timeSlotRepository = timeSlotRepository;
         _timelineService = timelineService;
         _scheduleStatusService = scheduleStatusService;
+        _tenancyContextAccessor = tenancyContextAccessor;
     }
 
     public async Task<Guid> Handle(AddScheduleCommand request)
@@ -38,12 +42,14 @@ public class AddScheduleCommandHandler
             throw new Exceptions.ValidationException(validationResult);
 
 
+        var tenantId = _tenancyContextAccessor.Current!.TenantId;
+
         var schedule = new Schedule
         {
             Id = Guid.NewGuid(),
             ChildId = request.ChildId,
             StartDate = request.StartDate,
-            TenantId = Guid.Parse("7e520828-45e6-415f-b0ba-19d56a312f7f") // Default tenant ID for now
+            TenantId = tenantId
         };
 
         // Create schedule rules
@@ -55,7 +61,8 @@ public class AddScheduleCommandHandler
                 ScheduleId = schedule.Id,
                 Day = rule.Day,
                 TimeSlotId = rule.TimeSlotId,
-                GroupId = rule.GroupId
+                GroupId = rule.GroupId,
+                TenantId = tenantId
             }).ToList();
         }
 

--- a/src/Services/Scheduling/Application/Features/TimeSlots/Commands/AddTimeSlot/AddTimeSlotCommandHandler.cs
+++ b/src/Services/Scheduling/Application/Features/TimeSlots/Commands/AddTimeSlot/AddTimeSlotCommandHandler.cs
@@ -2,16 +2,19 @@
 using System.Threading.Tasks;
 using KDVManager.Services.Scheduling.Application.Contracts.Persistence;
 using KDVManager.Services.Scheduling.Domain.Entities;
+using KDVManager.Shared.Contracts.Tenancy;
 
 namespace KDVManager.Services.Scheduling.Application.Features.TimeSlots.Commands.AddTimeSlot;
 
 public class AddTimeSlotCommandHandler
 {
     private readonly ITimeSlotRepository _timeSlotRepository;
+    private readonly ITenancyContextAccessor _tenancyContextAccessor;
 
-    public AddTimeSlotCommandHandler(ITimeSlotRepository timeSlotRepository)
+    public AddTimeSlotCommandHandler(ITimeSlotRepository timeSlotRepository, ITenancyContextAccessor tenancyContextAccessor)
     {
         _timeSlotRepository = timeSlotRepository;
+        _tenancyContextAccessor = tenancyContextAccessor;
     }
 
     public async Task<Guid> Handle(AddTimeSlotCommand request)
@@ -28,7 +31,7 @@ public class AddTimeSlotCommandHandler
             Name = request.Name,
             StartTime = request.StartTime,
             EndTime = request.EndTime,
-            TenantId = Guid.Parse("7e520828-45e6-415f-b0ba-19d56a312f7f") // Default tenant ID for now
+            TenantId = _tenancyContextAccessor.Current!.TenantId
         };
 
         timeSlot = await _timeSlotRepository.AddAsync(timeSlot);

--- a/src/Services/Scheduling/Infrastructure/ApplicationDbContext.cs
+++ b/src/Services/Scheduling/Infrastructure/ApplicationDbContext.cs
@@ -67,17 +67,41 @@ public class ApplicationDbContext : DbContext
 
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
     {
+        ApplyTenantToTrackedEntities();
+        var result = await base.SaveChangesAsync(cancellationToken);
+        return result;
+    }
+
+    public override int SaveChanges()
+    {
+        ApplyTenantToTrackedEntities();
+        return base.SaveChanges();
+    }
+
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        ApplyTenantToTrackedEntities();
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    /// <summary>
+    /// Stamps the current tenant onto every added or modified tenant-owned entity.
+    /// Re-stamping on Modified prevents a tenant identifier from being reassigned
+    /// via an update and guarantees isolation even if an entity was constructed
+    /// without an explicit TenantId.
+    /// </summary>
+    private void ApplyTenantToTrackedEntities()
+    {
+        var tenantId = _tenancyContextAccessor.Current!.TenantId;
         foreach (var entry in ChangeTracker.Entries<IMustHaveTenant>())
         {
             switch (entry.State)
             {
                 case EntityState.Added:
-                    entry.Entity.TenantId = _tenancyContextAccessor.Current!.TenantId;
+                case EntityState.Modified:
+                    entry.Entity.TenantId = tenantId;
                     break;
             }
         }
-
-        var result = await base.SaveChangesAsync(cancellationToken);
-        return result;
     }
 }

--- a/src/Shared/KDVManager.Shared.Contracts/Tenancy/TenancyClaimTypes.cs
+++ b/src/Shared/KDVManager.Shared.Contracts/Tenancy/TenancyClaimTypes.cs
@@ -1,0 +1,12 @@
+namespace KDVManager.Shared.Contracts.Tenancy;
+
+/// <summary>
+/// Well-known claim types used to carry tenant identity on authenticated requests.
+/// </summary>
+public static class TenancyClaimTypes
+{
+    /// <summary>
+    /// The namespaced custom claim minted by the identity provider that carries the tenant id.
+    /// </summary>
+    public const string TenantId = "https://kdvmanager.nl/tenant";
+}

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/JwtTenancyResolver.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/JwtTenancyResolver.cs
@@ -20,7 +20,7 @@ public class JwtTenancyResolver : ITenancyResolver
         if (claims == null)
             return null;
 
-        var tenantClaim = claims.FirstOrDefault(c => c.Type == "https://kdvmanager.nl/tenant");
+        var tenantClaim = claims.FirstOrDefault(c => c.Type == TenancyClaimTypes.TenantId);
         return tenantClaim != null && Guid.TryParse(tenantClaim.Value, out var guid)
             ? new StaticTenancyContext(guid)
             : null;

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/MassTransitTenancyConsumeFilter.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/MassTransitTenancyConsumeFilter.cs
@@ -17,17 +17,23 @@ public class MassTransitTenancyConsumeFilter<T> : IFilter<ConsumeContext<T>>
     {
         _tenancyContextAccessor = tenancyContextAccessor;
         _logger = logger;
-        _logger.LogInformation("MassTransitTenancyConsumeFilter initialized.");
     }
 
     public async Task Send(ConsumeContext<T> context, IPipe<ConsumeContext<T>> next)
     {
-        _logger.LogInformation("MassTransitTenancyConsumeFilter Send method called.");
-
         if (context.Headers.TryGetHeader("TenantId", out var tenantIdHeader) && tenantIdHeader is string tenantId)
         {
-            _logger.LogInformation("Setting TenantId in TenancyContext: {TenantId}", tenantId);
-            _tenancyContextAccessor.Current = new StaticTenancyContext(Guid.Parse(tenantId));
+            if (Guid.TryParse(tenantId, out var tenantGuid))
+            {
+                _logger.LogDebug("Setting TenantId in TenancyContext: {TenantId}", tenantGuid);
+                _tenancyContextAccessor.Current = new StaticTenancyContext(tenantGuid);
+            }
+            else
+            {
+                // Malformed tenant header: do not set a tenant. Downstream data access
+                // then fails closed via TenantRequiredException rather than throwing here.
+                _logger.LogWarning("Received message with malformed TenantId header: {TenantId}", tenantId);
+            }
         }
 
         await next.Send(context);

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/MassTransitTenancyPublishFilter.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/MassTransitTenancyPublishFilter.cs
@@ -17,19 +17,16 @@ public class MassTransitTenancyPublishFilter<T> : IFilter<PublishContext<T>>
     {
         _tenancyContextAccessor = tenancyContextAccessor;
         _logger = logger;
-        _logger.LogInformation("MassTransitTenancyPublishFilter initialized.");
     }
 
     public void Probe(ProbeContext context) { }
 
     public async Task Send(PublishContext<T> context, IPipe<PublishContext<T>> next)
     {
-        _logger.LogInformation("MassTransitTenancyPublishFilter Send method called.");
-
         var tenantId = _tenancyContextAccessor.Current?.TenantId;
         if (tenantId != null)
         {
-            _logger.LogInformation("Setting TenantId header: {TenantId}", tenantId);
+            _logger.LogDebug("Setting TenantId header: {TenantId}", tenantId);
             context.Headers.Set("TenantId", tenantId.ToString());
         }
 

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/MassTransitTenancySendFilter.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/MassTransitTenancySendFilter.cs
@@ -17,19 +17,16 @@ public class MassTransitTenancySendFilter<T> : IFilter<SendContext<T>>
     {
         _tenancyContextAccessor = tenancyContextAccessor;
         _logger = logger;
-        _logger.LogInformation("MassTransitTenancySendFilter initialized.");
     }
 
     public void Probe(ProbeContext context) { }
 
     public async Task Send(SendContext<T> context, IPipe<SendContext<T>> next)
     {
-        _logger.LogInformation("MassTransitTenancySendFilter Send method called.");
-
         var tenantId = _tenancyContextAccessor.Current?.TenantId;
         if (tenantId != null)
         {
-            _logger.LogInformation("Setting TenantId header: {TenantId}", tenantId);
+            _logger.LogDebug("Setting TenantId header: {TenantId}", tenantId);
             context.Headers.Set("TenantId", tenantId.ToString());
         }
 

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyMiddleware.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyMiddleware.cs
@@ -40,6 +40,19 @@ public class TenancyMiddleware
             }
         }
 
+        // No tenant could be resolved. If the caller is authenticated we must fail
+        // closed: an authenticated principal without a tenant claim must never be
+        // allowed to reach tenant-scoped resources. Anonymous requests (e.g. health
+        // checks / openapi) are left to the authorization layer to accept or reject.
+        if (context.User?.Identity?.IsAuthenticated == true)
+        {
+            logger.LogWarning("Authenticated request without a tenant claim was rejected. Path: {Path}", context.Request.Path);
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("{\"error\":\"Tenant context is required.\"}");
+            return;
+        }
+
         await _next(context);
     }
 }


### PR DESCRIPTION
Tenant isolation was fundamentally sound (EF global query filters +
SaveChanges stamping + fail-closed accessor + JWT tenant claim), but a
few gaps could allow cross-tenant data to be written or reached under
edge conditions. This hardens them:

- Remove hard-coded default tenant GUID from AddChild (CRM) and
  AddGroup/AddTimeSlot/AddSchedule (Scheduling); resolve the tenant from
  ITenancyContextAccessor instead. AddSchedule now stamps child
  ScheduleRules explicitly.
- Add a fallback authorization policy (RequireAuthenticatedUser) to both
  APIs so a request that bypasses the gateway is rejected instead of
  running anonymously; health checks and OpenAPI stay AllowAnonymous.
- TenancyMiddleware now returns 403 when an authenticated request has no
  tenant claim rather than relying solely on a downstream failure.
- Override synchronous SaveChanges in both DbContexts and re-stamp
  TenantId on Modified in Scheduling (was Added only).
- Consume filter uses Guid.TryParse and fails closed on a malformed
  TenantId header; downgrade per-message tenant logging to Debug.
- Centralize the tenant claim type in TenancyClaimTypes.
- Document the strategy and residual risks in docs/multi-tenancy.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nt2qaNhvwtA7sDBWADDt5v