### PR TITLE
Remove stray divider from list page header

### DIFF
--- a/src/web/src/components/layout/ListPageLayout.tsx
+++ b/src/web/src/components/layout/ListPageLayout.tsx
@@ -15,7 +15,6 @@ import ClearIcon from "@mui/icons-material/CloseRounded";
 import Typography from "@mui/material/Typography";
 import Chip from "@mui/material/Chip";
 import Fade from "@mui/material/Fade";
-import Divider from "@mui/material/Divider";
 
 const StyledToolbar = styled(Toolbar)<ToolbarProps>(({ theme }) => ({
   padding: 0,
@@ -222,7 +221,6 @@ export const ListPageLayout = ({
           )}
         </Box>
         {search && <ListPageSearchToolbar search={search} />}
-        <Divider flexItem sx={{ mt: 1 }} />
       </HeaderPaper>
       <Paper elevation={0} sx={{ p: { xs: 1, sm: 2 }, borderRadius: 3 }}>
         {children}


### PR DESCRIPTION
The ListPageLayout header (HeaderPaper) always rendered a Divider
below the title/search area, showing an unwanted horizontal rule at
the bottom of the top box on every list page, e.g. below the search
field on the children and guardians pages.