### PR TITLE
Show error alert instead of empty table when a list query fails

### DIFF
--- a/src/web/src/components/cards/MobileCardList.tsx
+++ b/src/web/src/components/cards/MobileCardList.tsx
@@ -4,10 +4,15 @@ import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
 import Pagination from "@mui/material/Pagination";
 import Skeleton from "@mui/material/Skeleton";
+import { QueryErrorAlert } from "@components/errors/QueryErrorAlert";
 
 type MobileCardListProps<T> = {
   items: T[] | undefined;
   isLoading: boolean;
+  /** Query error, if any. When set, an error alert replaces the list instead of an empty state. */
+  error?: unknown;
+  /** Called when the user clicks "Retry" in the error alert, e.g. the query's refetch. */
+  onRetry?: () => void;
   /** Total number of records across all pages. */
   total: number;
   getKey: (item: T) => string;
@@ -24,11 +29,17 @@ type MobileCardListProps<T> = {
 export const MobileCardList = <T,>({
   items,
   isLoading,
+  error,
+  onRetry,
   total,
   getKey,
   renderCard,
   pagination,
 }: MobileCardListProps<T>) => {
+  if (error) {
+    return <QueryErrorAlert error={error} onRetry={onRetry} />;
+  }
+
   if (isLoading && !items) {
     return (
       <Stack spacing={2}>

--- a/src/web/src/components/datagrid/AppDataGrid.tsx
+++ b/src/web/src/components/datagrid/AppDataGrid.tsx
@@ -1,9 +1,27 @@
 import { DataGrid, type DataGridProps, type GridValidRowModel } from "@mui/x-data-grid";
+import { QueryErrorAlert } from "@components/errors/QueryErrorAlert";
+
+type AppDataGridProps<R extends GridValidRowModel> = DataGridProps<R> & {
+  /** Query error, if any. When set, an error alert replaces the grid instead of an empty table. */
+  error?: unknown;
+  /** Called when the user clicks "Retry" in the error alert, e.g. the query's refetch. */
+  onRetry?: () => void;
+};
 
 /**
  * DataGrid with the app-wide defaults so every table looks and behaves the
  * same. Any prop can still be overridden per table.
  */
-export const AppDataGrid = <R extends GridValidRowModel>(props: DataGridProps<R>) => (
-  <DataGrid<R> autoHeight pageSizeOptions={[5, 10, 20]} disableRowSelectionOnClick {...props} />
-);
+export const AppDataGrid = <R extends GridValidRowModel>({
+  error,
+  onRetry,
+  ...props
+}: AppDataGridProps<R>) => {
+  if (error) {
+    return <QueryErrorAlert error={error} onRetry={onRetry} />;
+  }
+
+  return (
+    <DataGrid<R> autoHeight pageSizeOptions={[5, 10, 20]} disableRowSelectionOnClick {...props} />
+  );
+};

--- a/src/web/src/components/errors/QueryErrorAlert.tsx
+++ b/src/web/src/components/errors/QueryErrorAlert.tsx
@@ -1,0 +1,34 @@
+import { Alert, type AlertProps, Button } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { ApiError } from "@api/errors/types";
+
+type QueryErrorAlertProps = {
+  error: unknown;
+  onRetry?: () => void;
+  sx?: AlertProps["sx"];
+};
+
+/**
+ * Shared error state for query-backed lists/tables. ApiError messages are
+ * already localized by buildApiError, so we can render them directly.
+ */
+export const QueryErrorAlert = ({ error, onRetry, sx }: QueryErrorAlertProps) => {
+  const { t } = useTranslation();
+  const message = error instanceof ApiError ? error.message : t("error.unexpected");
+
+  return (
+    <Alert
+      severity="error"
+      sx={sx}
+      action={
+        onRetry ? (
+          <Button color="inherit" size="small" onClick={onRetry}>
+            {t("Retry")}
+          </Button>
+        ) : undefined
+      }
+    >
+      {message}
+    </Alert>
+  );
+};

--- a/src/web/src/features/absence/AbsenceList.tsx
+++ b/src/web/src/features/absence/AbsenceList.tsx
@@ -16,13 +16,14 @@ import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 dayjs.extend(isSameOrAfter);
 import { useTranslation } from "react-i18next";
 import { useGetAbsencesByChildId } from "@api/scheduling/endpoints/absences/absences";
+import { QueryErrorAlert } from "@components/errors/QueryErrorAlert";
 import { DeleteAbsenceButton } from "./DeleteAbsenceButton";
 
 type AbsenceListProps = { childId: string };
 
 export const AbsenceList: React.FC<AbsenceListProps> = ({ childId }) => {
   const { t } = useTranslation();
-  const { data: absencesRaw, isLoading } = useGetAbsencesByChildId(childId);
+  const { data: absencesRaw, isLoading, error, refetch } = useGetAbsencesByChildId(childId);
   const [view, setView] = useState<"future" | "past">("future");
 
   const loadingSkeleton = (
@@ -66,6 +67,10 @@ export const AbsenceList: React.FC<AbsenceListProps> = ({ childId }) => {
           futureAbsences[0],
         )
       : null;
+
+  if (error) {
+    return <QueryErrorAlert error={error} onRetry={refetch} />;
+  }
 
   return (
     <Box>

--- a/src/web/src/features/children/ChildrenTable.test.tsx
+++ b/src/web/src/features/children/ChildrenTable.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { page, userEvent } from "vitest/browser";
 import NiceModal from "@ebay/nice-modal-react";
 import { SnackbarProvider } from "notistack";
+import { ApiError } from "@api/errors/types";
 
 import { renderWithProviders } from "../../test/renderWithProviders";
 
@@ -28,6 +29,8 @@ const CHILDREN = vi.hoisted(() => [
   },
 ]);
 
+const useListChildrenMock = vi.hoisted(() => vi.fn());
+
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
@@ -37,7 +40,7 @@ vi.mock("react-router-dom", async () => {
 });
 
 vi.mock("@api/crm/endpoints/children/children", () => ({
-  useListChildren: () => ({ data: CHILDREN, isLoading: false, isFetching: false }),
+  useListChildren: useListChildrenMock,
   useDeleteChild: () => ({ mutateAsync: vi.fn(), isPending: false }),
   getListChildrenQueryKey: () => ["children"],
 }));
@@ -58,6 +61,14 @@ const renderTable = async () => {
 
 beforeEach(() => {
   navigateMock.mockReset();
+  useListChildrenMock.mockReset();
+  useListChildrenMock.mockReturnValue({
+    data: CHILDREN,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  });
 });
 
 describe("ChildrenTable — record navigation (browser)", () => {
@@ -91,5 +102,45 @@ describe("ChildrenTable — record navigation (browser)", () => {
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledWith("/children/child-2");
+  });
+});
+
+describe("ChildrenTable — server error state (browser)", () => {
+  it("shows an error alert instead of an empty table when the query fails (desktop)", async () => {
+    const refetchMock = vi.fn();
+    useListChildrenMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new ApiError({ message: "Server error", status: 500, type: "server" }),
+      refetch: refetchMock,
+    });
+
+    await page.viewport(1280, 800);
+    await renderTable();
+
+    await expect.element(page.getByText("Server error")).toBeVisible();
+
+    await userEvent.click(page.getByRole("button", { name: "Retry" }));
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error alert instead of an empty list when the query fails (mobile)", async () => {
+    const refetchMock = vi.fn();
+    useListChildrenMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: new ApiError({ message: "Server error", status: 500, type: "server" }),
+      refetch: refetchMock,
+    });
+
+    await page.viewport(375, 667);
+    await renderTable();
+
+    await expect.element(page.getByText("Server error")).toBeVisible();
+
+    await userEvent.click(page.getByRole("button", { name: "Retry" }));
+    expect(refetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/src/features/children/ChildrenTable.tsx
+++ b/src/web/src/features/children/ChildrenTable.tsx
@@ -84,7 +84,7 @@ export const ChildrenTable = () => {
   const navigate = useNavigate();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const { apiParams, muiPagination } = useChildrenListState();
-  const { data, isLoading, isFetching } = useListChildren(
+  const { data, isLoading, isFetching, error, refetch } = useListChildren(
     { ...apiParams },
     {
       query: { placeholderData: keepPreviousData },
@@ -142,6 +142,8 @@ export const ChildrenTable = () => {
       <MobileCardList<ChildListVM>
         items={data}
         isLoading={isLoading}
+        error={error}
+        onRetry={refetch}
         total={getTotal(data)}
         getKey={(child) => child.id!}
         pagination={muiPagination}
@@ -175,6 +177,8 @@ export const ChildrenTable = () => {
       <AppDataGrid<ChildListVM>
         rowCount={getTotal(data)}
         loading={isLoading || isFetching}
+        error={error}
+        onRetry={refetch}
         columns={columns}
         rows={data ?? []}
         {...muiPagination}

--- a/src/web/src/features/closurePeriods/ClosurePeriodsTable.tsx
+++ b/src/web/src/features/closurePeriods/ClosurePeriodsTable.tsx
@@ -11,7 +11,7 @@ import { DeleteClosurePeriodButton } from "./DeleteClosurePeriodButton";
 
 export const ClosurePeriodsTable = () => {
   const { t } = useTranslation();
-  const { data, isLoading } = useListClosurePeriods();
+  const { data, isLoading, error, refetch } = useListClosurePeriods();
 
   const columns: GridColDef<ClosurePeriod>[] = useMemo(
     () => [
@@ -49,6 +49,8 @@ export const ClosurePeriodsTable = () => {
       rows={Array.isArray(data) ? data : []}
       getRowId={(row) => row.id ?? `${row.startDate}-${row.endDate}-${row.reason}`}
       loading={isLoading}
+      error={error}
+      onRetry={refetch}
     />
   );
 };

--- a/src/web/src/features/groups/GroupsTable.tsx
+++ b/src/web/src/features/groups/GroupsTable.tsx
@@ -15,7 +15,7 @@ const GroupsTable = () => {
   const { t } = useTranslation();
   const { apiParams, muiPagination } = useGroupsListState();
 
-  const { data, isLoading, isFetching } = useListGroups(apiParams, {
+  const { data, isLoading, isFetching, error, refetch } = useListGroups(apiParams, {
     query: { placeholderData: keepPreviousData },
   });
 
@@ -41,6 +41,8 @@ const GroupsTable = () => {
     <AppDataGrid<GroupListVM>
       rowCount={getTotal(data)}
       loading={isLoading || isFetching}
+      error={error}
+      onRetry={refetch}
       columns={columns}
       rows={data ?? []}
       {...muiPagination}

--- a/src/web/src/features/guardians/GuardiansTable.tsx
+++ b/src/web/src/features/guardians/GuardiansTable.tsx
@@ -26,7 +26,7 @@ export const GuardiansTable = () => {
   const navigate = useNavigate();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const { apiParams, muiPagination } = useGuardiansListState();
-  const { data, isLoading, isFetching } = useListGuardians(apiParams, {
+  const { data, isLoading, isFetching, error, refetch } = useListGuardians(apiParams, {
     query: { placeholderData: keepPreviousData },
   });
 
@@ -78,6 +78,8 @@ export const GuardiansTable = () => {
       <MobileCardList<GuardianListVM>
         items={data}
         isLoading={isLoading}
+        error={error}
+        onRetry={refetch}
         total={getTotal(data)}
         getKey={(guardian) => guardian.id!}
         pagination={muiPagination}
@@ -112,6 +114,8 @@ export const GuardiansTable = () => {
       <AppDataGrid<GuardianListVM>
         rowCount={getTotal(data)}
         loading={isLoading || isFetching}
+        error={error}
+        onRetry={refetch}
         columns={columns}
         rows={data ?? []}
         {...muiPagination}

--- a/src/web/src/features/timeSlots/TimeSlotsTable.tsx
+++ b/src/web/src/features/timeSlots/TimeSlotsTable.tsx
@@ -20,7 +20,7 @@ const TimeSlotsTable = () => {
   const { t } = useTranslation();
   const { apiParams, muiPagination } = useTimeSlotsListState();
 
-  const { data, isLoading, isFetching } = useListTimeSlots(apiParams, {
+  const { data, isLoading, isFetching, error, refetch } = useListTimeSlots(apiParams, {
     query: { placeholderData: keepPreviousData },
   });
 
@@ -75,6 +75,8 @@ const TimeSlotsTable = () => {
     <AppDataGrid<TimeSlotListVM>
       rowCount={getTotal(data)}
       loading={isLoading || isFetching}
+      error={error}
+      onRetry={refetch}
       columns={columns}
       rows={data ?? []}
       getRowId={(row) => row.id ?? `${row.name}-${row.startTime}-${row.endTime}`}


### PR DESCRIPTION
## Summary
- Server errors (500 / service unavailable) on list queries rendered tables and forms as silently empty — no error was ever shown to the user.
- Root cause: `ChildrenTable`, `GuardiansTable`, `GroupsTable`, `TimeSlotsTable`, `ClosurePeriodsTable`, and `AbsenceList` only destructured `data`/`isLoading` from their react-query hooks. On failure `data` stays `undefined` while `isLoading` settles to `false`, so the grid/list falls back to its normal "no rows" empty state — indistinguishable from a genuinely empty dataset.
- Added a shared `QueryErrorAlert` component that renders the already-localized `ApiError` message with a Retry action, and wired `error`/`refetch` through the two shared list primitives (`AppDataGrid`, `MobileCardList`) plus `AbsenceList`, so a failed query now shows a clear error with retry instead of an empty table.

## Test plan
- [x] `tsc -b && tsc -p tsconfig.test.json` passes
- [x] `eslint` passes on all changed files
- [x] Full `vitest` browser suite passes (20/20), including two new regression tests in `ChildrenTable.test.tsx` that simulate a 500 response and assert the error alert renders with a working Retry button, on both desktop (grid) and mobile (card list) layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012gruqfipAoh34Ebah6hxHW)_