### PR TITLE
Add SigNoz alert rules as code with idempotent apply script

### DIFF
--- a/docs/observability-setup.md
+++ b/docs/observability-setup.md
@@ -91,10 +91,13 @@ points the web build at `http://localhost:5200/telemetry`. Services pick up the 
 
 ## Known gaps / follow-ups
 
-1. **Alerting**: SigNoz alert rules + a notification channel are not yet configured (do this in the
-   SigNoz UI), and there is no external uptime check for kdvmanager.nl itself.
+1. **Alerting**: starter alert rules live in [`scripts/signoz/`](../scripts/signoz/README.md) and are
+   applied with `SIGNOZ_API_KEY=… ./apply_alerts.py`. A notification channel must still be added once
+   in the SigNoz UI (Settings → Alert Channels), and there is no external uptime check for
+   kdvmanager.nl itself.
 2. **Rate limiting**: `/telemetry/` is unauthenticated by design; an Envoy `local_ratelimit` on that
    route is recommended.
-3. **Retention**: set explicitly in SigNoz (Settings → General); ClickHouse disk is small (5Gi).
+3. **Retention**: `./apply_alerts.py --retention traces=360h logs=360h metrics=720h` (or SigNoz
+   Settings → General); ClickHouse disk is small (5Gi).
 4. **Business metrics**: the per-service meters currently only count errors — domain metrics
    (schedules created, registrations, absences) belong there.

--- a/scripts/signoz/README.md
+++ b/scripts/signoz/README.md
@@ -1,0 +1,45 @@
+# SigNoz alerting as code
+
+Starter alert rules for the KDVManager observability stack, applied via the SigNoz API so they are
+versioned here instead of living only in the UI.
+
+## Rules
+
+| File | Alert | Fires when |
+|---|---|---|
+| `alerts/api-error-rate.json` | High API error count | Error-span rate per service above threshold (5m) |
+| `alerts/api-latency-p99.json` | High API p99 latency | p99 > 2s for a full 5m window |
+| `alerts/pod-restarts.json` | Container restarting | Any container restarted > 3 times |
+| `alerts/telemetry-pipeline-down.json` | Telemetry pipeline down | No APM data at all for 10m (absence alert) |
+| `alerts/container-memory.json` | Container memory near limit | > 90% of the memory limit for 10m |
+
+## Usage
+
+```bash
+# 1. Create an API key: SigNoz UI -> Settings -> API Keys (role: Admin)
+export SIGNOZ_API_KEY=...
+
+# 2. Preview, then apply (idempotent: rules are upserted by name)
+./apply_alerts.py --dry-run
+./apply_alerts.py
+
+# Optional: set data retention explicitly (ClickHouse disk is small)
+./apply_alerts.py --retention traces=360h logs=360h metrics=720h
+```
+
+`SIGNOZ_URL` overrides the default `https://signoz.kdvmanager.nl`.
+
+## Notes
+
+- **Notification channel**: rules have no `preferredChannels`, so they notify every configured
+  channel. Add a channel once in the UI (Settings → Alert Channels — Slack webhook or email; email
+  requires SMTP configured on the SigNoz deployment). Rules-as-code can pin channel names later via
+  `preferredChannels`.
+- **Schema caveat**: the builder-query JSON was written against the SigNoz v0.88.x API but has not
+  been validated against a live instance from this repo. The API validates on apply — if a rule is
+  rejected, create the equivalent rule once in the UI, `GET /api/v1/rules`, and align the JSON with
+  what the UI produced.
+- The MassTransit consumer-fault alert from the review is intentionally not included yet: add it once
+  the bus metrics are visible in SigNoz and the exact metric name is known.
+- An **external uptime check** (e.g. a free healthcheck service watching kdvmanager.nl) is still
+  recommended — SigNoz cannot alert on its own cluster being down.

--- a/scripts/signoz/alerts/api-error-rate.json
+++ b/scripts/signoz/alerts/api-error-rate.json
@@ -1,0 +1,69 @@
+{
+  "alert": "High API error count",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "evalWindow": "5m0s",
+  "frequency": "1m0s",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "unit": "",
+      "builderQueries": {
+        "A": {
+          "queryName": "A",
+          "dataSource": "metrics",
+          "aggregateAttribute": {
+            "key": "signoz_calls_total",
+            "dataType": "float64",
+            "type": "Sum",
+            "isColumn": true
+          },
+          "timeAggregation": "rate",
+          "spaceAggregation": "sum",
+          "aggregateOperator": "sum_rate",
+          "expression": "A",
+          "disabled": false,
+          "stepInterval": 60,
+          "filters": {
+            "op": "AND",
+            "items": [
+              {
+                "key": {
+                  "key": "status_code",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                "op": "=",
+                "value": "STATUS_CODE_ERROR"
+              }
+            ]
+          },
+          "groupBy": [
+            {
+              "key": "service_name",
+              "dataType": "string",
+              "type": "resource",
+              "isColumn": false
+            }
+          ],
+          "legend": "{{service_name}}",
+          "reduceTo": "sum"
+        }
+      }
+    },
+    "op": "1",
+    "target": 0.05,
+    "matchType": "1",
+    "selectedQueryName": "A"
+  },
+  "labels": {
+    "severity": "critical"
+  },
+  "annotations": {
+    "summary": "Error span rate above threshold for {{$labels.service_name}}",
+    "description": "The rate of error spans (status_code=STATUS_CODE_ERROR) for {{$labels.service_name}} exceeded the threshold over the last 5 minutes. Check SigNoz Exceptions and recent traces for this service."
+  },
+  "preferredChannels": []
+}

--- a/scripts/signoz/alerts/api-latency-p99.json
+++ b/scripts/signoz/alerts/api-latency-p99.json
@@ -1,0 +1,58 @@
+{
+  "alert": "High API p99 latency",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "evalWindow": "5m0s",
+  "frequency": "1m0s",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "unit": "ns",
+      "builderQueries": {
+        "A": {
+          "queryName": "A",
+          "dataSource": "metrics",
+          "aggregateAttribute": {
+            "key": "signoz_latency",
+            "dataType": "float64",
+            "type": "Histogram",
+            "isColumn": true
+          },
+          "timeAggregation": "",
+          "spaceAggregation": "p99",
+          "aggregateOperator": "hist_quantile_99",
+          "expression": "A",
+          "disabled": false,
+          "stepInterval": 60,
+          "filters": {
+            "op": "AND",
+            "items": []
+          },
+          "groupBy": [
+            {
+              "key": "service_name",
+              "dataType": "string",
+              "type": "resource",
+              "isColumn": false
+            }
+          ],
+          "legend": "{{service_name}}",
+          "reduceTo": "max"
+        }
+      }
+    },
+    "op": "1",
+    "target": 2000000000,
+    "matchType": "2",
+    "selectedQueryName": "A"
+  },
+  "labels": {
+    "severity": "warning"
+  },
+  "annotations": {
+    "summary": "p99 latency above 2s for {{$labels.service_name}}",
+    "description": "The 99th percentile request latency for {{$labels.service_name}} stayed above 2 seconds for the whole 5 minute window. Check database spans (Npgsql) and downstream calls in the slowest traces."
+  },
+  "preferredChannels": []
+}

--- a/scripts/signoz/alerts/container-memory.json
+++ b/scripts/signoz/alerts/container-memory.json
@@ -1,0 +1,58 @@
+{
+  "alert": "Container memory near limit",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "evalWindow": "10m0s",
+  "frequency": "5m0s",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "unit": "",
+      "builderQueries": {
+        "A": {
+          "queryName": "A",
+          "dataSource": "metrics",
+          "aggregateAttribute": {
+            "key": "k8s_container_memory_limit_utilization",
+            "dataType": "float64",
+            "type": "Gauge",
+            "isColumn": true
+          },
+          "timeAggregation": "avg",
+          "spaceAggregation": "max",
+          "aggregateOperator": "avg",
+          "expression": "A",
+          "disabled": false,
+          "stepInterval": 60,
+          "filters": {
+            "op": "AND",
+            "items": []
+          },
+          "groupBy": [
+            {
+              "key": "k8s_pod_name",
+              "dataType": "string",
+              "type": "resource",
+              "isColumn": false
+            }
+          ],
+          "legend": "{{k8s_pod_name}}",
+          "reduceTo": "max"
+        }
+      }
+    },
+    "op": "1",
+    "target": 0.9,
+    "matchType": "2",
+    "selectedQueryName": "A"
+  },
+  "labels": {
+    "severity": "warning"
+  },
+  "annotations": {
+    "summary": "{{$labels.k8s_pod_name}} memory above 90% of its limit",
+    "description": "Container memory utilization stayed above 90% of the configured limit for 10 minutes (kubeletstats). The workload resource limits are tuned tightly for this cluster — check for a leak or raise the limit in the deployment manifest."
+  },
+  "preferredChannels": []
+}

--- a/scripts/signoz/alerts/pod-restarts.json
+++ b/scripts/signoz/alerts/pod-restarts.json
@@ -1,0 +1,58 @@
+{
+  "alert": "Container restarting",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "evalWindow": "15m0s",
+  "frequency": "5m0s",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "unit": "",
+      "builderQueries": {
+        "A": {
+          "queryName": "A",
+          "dataSource": "metrics",
+          "aggregateAttribute": {
+            "key": "k8s_container_restarts",
+            "dataType": "float64",
+            "type": "Gauge",
+            "isColumn": true
+          },
+          "timeAggregation": "max",
+          "spaceAggregation": "max",
+          "aggregateOperator": "max",
+          "expression": "A",
+          "disabled": false,
+          "stepInterval": 60,
+          "filters": {
+            "op": "AND",
+            "items": []
+          },
+          "groupBy": [
+            {
+              "key": "k8s_pod_name",
+              "dataType": "string",
+              "type": "resource",
+              "isColumn": false
+            }
+          ],
+          "legend": "{{k8s_pod_name}}",
+          "reduceTo": "max"
+        }
+      }
+    },
+    "op": "1",
+    "target": 3,
+    "matchType": "1",
+    "selectedQueryName": "A"
+  },
+  "labels": {
+    "severity": "critical"
+  },
+  "annotations": {
+    "summary": "Pod {{$labels.k8s_pod_name}} has restarted more than 3 times",
+    "description": "Container restart count exceeded 3 (collected via the kubeletstats receiver). Check `kubectl describe pod` and the container logs; readiness (/readyz) failures point at Postgres or RabbitMQ connectivity."
+  },
+  "preferredChannels": []
+}

--- a/scripts/signoz/alerts/telemetry-pipeline-down.json
+++ b/scripts/signoz/alerts/telemetry-pipeline-down.json
@@ -1,0 +1,53 @@
+{
+  "alert": "Telemetry pipeline down (no APM data)",
+  "alertType": "METRIC_BASED_ALERT",
+  "ruleType": "threshold_rule",
+  "evalWindow": "10m0s",
+  "frequency": "5m0s",
+  "condition": {
+    "compositeQuery": {
+      "queryType": "builder",
+      "panelType": "graph",
+      "unit": "",
+      "builderQueries": {
+        "A": {
+          "queryName": "A",
+          "dataSource": "metrics",
+          "aggregateAttribute": {
+            "key": "signoz_calls_total",
+            "dataType": "float64",
+            "type": "Sum",
+            "isColumn": true
+          },
+          "timeAggregation": "rate",
+          "spaceAggregation": "sum",
+          "aggregateOperator": "sum_rate",
+          "expression": "A",
+          "disabled": false,
+          "stepInterval": 60,
+          "filters": {
+            "op": "AND",
+            "items": []
+          },
+          "groupBy": [],
+          "legend": "all services",
+          "reduceTo": "sum"
+        }
+      }
+    },
+    "op": "1",
+    "target": 1000000,
+    "matchType": "1",
+    "selectedQueryName": "A",
+    "alertOnAbsent": true,
+    "absentFor": 10
+  },
+  "labels": {
+    "severity": "critical"
+  },
+  "annotations": {
+    "summary": "No APM telemetry received for 10 minutes",
+    "description": "SigNoz stopped receiving span metrics from every service. Either all workloads are down or the telemetry pipeline broke: check the otel-collector in the observability namespace (health :13133) and the SigNoz collector in the signoz namespace. Note: the threshold itself is intentionally unreachable; this rule only fires via alertOnAbsent."
+  },
+  "preferredChannels": []
+}

--- a/scripts/signoz/apply_alerts.py
+++ b/scripts/signoz/apply_alerts.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Apply the alert rules in ./alerts to a SigNoz instance, idempotently.
+
+Rules are matched by their "alert" (name) field: existing rules with the same
+name are updated in place, new ones are created. Rules that exist only in
+SigNoz are left untouched, so UI-managed alerts are safe.
+
+Usage:
+  SIGNOZ_API_KEY=... ./apply_alerts.py [--url https://signoz.kdvmanager.nl] [--dry-run]
+  SIGNOZ_API_KEY=... ./apply_alerts.py --retention traces=360h logs=360h metrics=720h
+
+The API key is a SigNoz PAT (SigNoz UI -> Settings -> API Keys, role Admin).
+Stdlib only; no dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ALERTS_DIR = Path(__file__).parent / "alerts"
+
+
+def request(base_url: str, api_key: str, path: str, method: str = "GET", body: dict | None = None) -> dict:
+    url = base_url.rstrip("/") + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("SIGNOZ-API-KEY", api_key)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = resp.read().decode() or "{}"
+            return json.loads(payload)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        raise SystemExit(f"{method} {path} failed with HTTP {e.code}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise SystemExit(f"{method} {url} unreachable: {e.reason}") from e
+
+
+def existing_rules(base_url: str, api_key: str) -> dict[str, str]:
+    """Return {alert name: rule id} for rules already present in SigNoz."""
+    payload = request(base_url, api_key, "/api/v1/rules")
+    data = payload.get("data", payload)
+    rules = data.get("rules", data) if isinstance(data, dict) else data
+    result: dict[str, str] = {}
+    for rule in rules or []:
+        name = rule.get("alert") or rule.get("data", {}).get("alert")
+        rule_id = str(rule.get("id"))
+        if name and rule_id:
+            result[name] = rule_id
+    return result
+
+
+def apply_rules(base_url: str, api_key: str, dry_run: bool) -> None:
+    files = sorted(ALERTS_DIR.glob("*.json"))
+    if not files:
+        raise SystemExit(f"no rule files found in {ALERTS_DIR}")
+    current = existing_rules(base_url, api_key)
+    for f in files:
+        rule = json.loads(f.read_text())
+        name = rule["alert"]
+        if name in current:
+            action, method, path = "update", "PUT", f"/api/v1/rules/{current[name]}"
+        else:
+            action, method, path = "create", "POST", "/api/v1/rules"
+        if dry_run:
+            print(f"[dry-run] would {action} '{name}' ({f.name})")
+            continue
+        request(base_url, api_key, path, method, rule)
+        print(f"{action}d '{name}' ({f.name})")
+
+
+def set_retention(base_url: str, api_key: str, settings: list[str], dry_run: bool) -> None:
+    for setting in settings:
+        signal, _, duration = setting.partition("=")
+        if signal not in ("traces", "logs", "metrics") or not duration.endswith("h"):
+            raise SystemExit(f"invalid retention setting '{setting}' (expected e.g. traces=360h)")
+        query = urllib.parse.urlencode({"type": signal, "duration": duration})
+        if dry_run:
+            print(f"[dry-run] would set {signal} retention to {duration}")
+            continue
+        request(base_url, api_key, f"/api/v1/settings/ttl?{query}", "POST")
+        print(f"set {signal} retention to {duration}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--url", default=os.environ.get("SIGNOZ_URL", "https://signoz.kdvmanager.nl"))
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--retention", nargs="+", metavar="SIGNAL=DURATION",
+                        help="only set retention TTLs (e.g. traces=360h logs=360h metrics=720h)")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("SIGNOZ_API_KEY")
+    if not api_key:
+        raise SystemExit("SIGNOZ_API_KEY environment variable is required")
+
+    if args.retention:
+        set_retention(args.url, api_key, args.retention, args.dry_run)
+    else:
+        apply_rules(args.url, api_key, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
+++ b/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
@@ -34,7 +34,7 @@ static_resources:
                   allow_origin_string_match:
                   - safe_regex:
                       regex: ".*"
-                  allow_headers: content-type,authorization
+                  allow_headers: content-type,authorization,traceparent,tracestate
                   allow_methods: GET, POST, PUT, HEAD, OPTIONS, DELETE
                   expose_headers: x-Total
               routes:

--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -52,6 +52,10 @@ services:
         VITE_APP_AUTH0_DOMAIN: http://localhost:5300
         VITE_APP_AUTH0_CLIENT_ID: e2e-client
         VITE_API_BASE_URL: //localhost:5200
+        # compose merges build.args maps key-wise; without an explicit empty
+        # value the production telemetry endpoint from docker-compose.yml
+        # leaks into the e2e image
+        VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ""
     volumes:
       - ./web/nginx/nginx.e2e.conf:/etc/nginx/conf.d/default.conf:ro
     ports:


### PR DESCRIPTION
## Summary

Follow-up to #765, closing the alerting gap (finding C1 of the observability review) as far as it can be closed from the repo:

- **`scripts/signoz/alerts/`** — five starter alert rules as versioned JSON:
  1. High API error count (error spans per service, 5m window)
  2. High API p99 latency (> 2s sustained for 5m)
  3. Container restarting (> 3 restarts, via kubeletstats)
  4. Telemetry pipeline down (absence alert: no APM data for 10m)
  5. Container memory near limit (> 90% of limit for 10m — the cluster's limits are tuned tight)
- **`scripts/signoz/apply_alerts.py`** — stdlib-only, idempotent upsert by alert name against the SigNoz API (`SIGNOZ_API_KEY` PAT); existing UI-managed rules are never touched. Also supports `--retention traces=360h logs=360h metrics=720h` for explicit TTLs (the ClickHouse disk is 5Gi) and `--dry-run`.
- `docs/observability-setup.md` known-gaps section updated to point at the script.

## What still needs a human / one-time UI step

- Run the script with an Admin API key (SigNoz UI → Settings → API Keys). Not run from this environment: the sandbox network policy blocks `signoz.kdvmanager.nl` and no API key was available.
- Add a notification channel once in the UI (Slack webhook or email w/ SMTP); rules currently notify all channels.
- The rule JSON targets the v0.88.x builder-query schema but is unvalidated against a live instance — the API validates on apply, and the README documents how to reconcile if a rule is rejected.

## Verification

- All rule files parse as JSON; script syntax/arg handling and unreachable-host error paths exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xu8Z1AmQCNhDEaP6A1SQY

---
_Generated by [Claude Code](https://claude.ai/code/session_014xu8Z1AmQCNhDEaP6A1SQY)_