### PR TITLE
Enhance observability with tenant context and rate limiting

### DIFF
--- a/deploy/k8s/applications/crm/deployment.yml
+++ b/deploy/k8s/applications/crm/deployment.yml
@@ -136,12 +136,6 @@ spec:
             drop:
             - ALL
         env:
-          - name: OTEL__ENDPOINT
-            value: "http://otel-collector.observability.svc.cluster.local:4317"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "http://otel-collector.observability.svc.cluster.local:4317"
-          - name: OTEL_SERVICE_NAME
-            value: "crm-migrator"
           - name: POSTGRES_SERVER
             value: "private-db-kdvmanager-ams3-do-user-13194146-0.l.db.ondigitalocean.com"
           - name: POSTGRES_USER

--- a/deploy/k8s/applications/scheduling/deployment.yml
+++ b/deploy/k8s/applications/scheduling/deployment.yml
@@ -136,12 +136,6 @@ spec:
             drop:
             - ALL
         env:
-          - name: OTEL__ENDPOINT
-            value: "http://otel-collector.observability.svc.cluster.local:4317"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "http://otel-collector.observability.svc.cluster.local:4317"
-          - name: OTEL_SERVICE_NAME
-            value: "scheduling-migrator"
           - name: POSTGRES_SERVER
             value: "private-db-kdvmanager-ams3-do-user-13194146-0.l.db.ondigitalocean.com"
           - name: POSTGRES_USER

--- a/deploy/k8s/infrastructure/envoy/envoy.yaml
+++ b/deploy/k8s/infrastructure/envoy/envoy.yaml
@@ -98,10 +98,37 @@ static_resources:
                 route:
                   prefix_rewrite: /
                   cluster: otel-collector-http
+                # Bounds the unauthenticated telemetry ingest per Envoy pod (60 burst / 30 rps).
+                typed_per_filter_config:
+                  envoy.filters.http.local_ratelimit:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                    stat_prefix: telemetry_rate_limiter
+                    token_bucket:
+                      max_tokens: 60
+                      tokens_per_fill: 30
+                      fill_interval: 1s
+                    filter_enabled:
+                      runtime_key: telemetry_rate_limit_enabled
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    filter_enforced:
+                      runtime_key: telemetry_rate_limit_enforced
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    status:
+                      code: TooManyRequests
           http_filters:
           - name: envoy.filters.http.cors
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+          # No-op at the listener level (no token_bucket): rate limiting only
+          # applies where a route sets typed_per_filter_config (telemetry).
+          - name: envoy.filters.http.local_ratelimit
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              stat_prefix: http_local_rate_limiter
           - name: envoy.filters.http.jwt_authn
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication

--- a/deploy/k8s/observability/otel-collector-config.yaml
+++ b/deploy/k8s/observability/otel-collector-config.yaml
@@ -53,8 +53,23 @@ data:
             value: kdvmanager-prod
             action: upsert
       memory_limiter:
-        limit_mib: 512
+        # Keep headroom below the container memory limit (512Mi) so the limiter engages before the kernel OOM-kills
+        limit_mib: 400
+        spike_limit_mib: 100
         check_interval: 1s
+      # Enrich OTLP telemetry with pod/namespace attribution from the Kubernetes API
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.deployment.name
+            - k8s.node.name
+        pod_association:
+          - sources:
+              - from: connection
       filter/ottl:
         error_mode: ignore
         traces:
@@ -82,13 +97,13 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, resource, filter/ottl, batch]
+          processors: [memory_limiter, k8sattributes, resource, filter/ottl, batch]
           exporters: [otlp/signoz]
         metrics:
           receivers: [otlp, prometheus, k8s_cluster, kubeletstats]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, k8sattributes, resource, batch]
           exporters: [otlp/signoz]
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, k8sattributes, resource, batch]
           exporters: [otlp/signoz]

--- a/deploy/k8s/observability/otel-collector-deployment.yaml
+++ b/deploy/k8s/observability/otel-collector-deployment.yaml
@@ -34,10 +34,6 @@ spec:
             - containerPort: 4318 # OTLP HTTP
               name: otlp-http
           env:
-            - name: K8S_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: K8S_NODE_IP
               valueFrom:
                 fieldRef:

--- a/docs/observability-setup.md
+++ b/docs/observability-setup.md
@@ -32,10 +32,14 @@ One shared bootstrap wires everything, so the services cannot drift:
 - `KDVManager.Shared.Infrastructure/Telemetry/TelemetryExtensions.cs` —
   `services.AddKdvManagerTelemetry(configuration, "<service-name>", <meter names…>)` sets up:
   - **Tracing**: ASP.NET Core (with exception recording and request/response enrichment), HttpClient,
-    **Npgsql** (database spans), MassTransit. Parent-based ratio sampling, configured via
+    **Npgsql** (database spans), MassTransit. Every span started within a tenant flow (HTTP request or
+    MassTransit consume) is stamped with `tenant.id` by `TenantEnrichmentProcessor`, backed by the
+    AsyncLocal `TenancyContextAccessor`. Parent-based ratio sampling, configured via
     `Otel:TraceSamplingRatio` or `OTEL_TRACE_SAMPLING_RATIO` (default 1.0).
-  - **Metrics**: ASP.NET Core, HttpClient, .NET runtime, MassTransit bus metrics, plus each service's
-    custom meter (`crm-api` / `scheduling-api`, used for the error counter in the exception middleware).
+  - **Metrics**: ASP.NET Core, HttpClient, .NET runtime, Npgsql connection metrics, MassTransit bus
+    metrics, plus each service's custom meter (`crm-api` / `scheduling-api`, used for the error counter
+    in the exception middleware).
+  - JWT authentication failures are logged as warnings (`JwtAuthentication` category, reason only).
   - OTLP export is enabled only when `Otel:Endpoint` (or `OTEL_EXPORTER_OTLP_ENDPOINT`) is set.
 - `Telemetry/KdvResource.cs` — one resource definition (service.name/namespace/version/instance,
   deployment.environment, host.name) shared by traces, metrics, **and** logs.
@@ -60,7 +64,8 @@ One shared bootstrap wires everything, so the services cannot drift:
 - **Web vitals**: CLS/INP/LCP/FCP/TTFB emitted as `web.vital` spans.
 
 Browser telemetry is POSTed to `https://api.kdvmanager.nl/telemetry/v1/traces` — an Envoy route
-(JWT-exempt, CORS-guarded) that forwards to the collector's OTLP/HTTP port 4318. Production builds get
+(JWT-exempt, CORS-guarded, rate-limited to 30 rps with a 60-token burst per Envoy pod via
+`local_ratelimit`) that forwards to the collector's OTLP/HTTP port 4318. Production builds get
 the endpoint and `VITE_APP_VERSION` (image tag) via build args in `src/docker-compose.yml`.
 
 ## Envoy gateway
@@ -93,8 +98,9 @@ points the web build at `http://localhost:5200/telemetry`. Services pick up the 
 
 1. **Alerting**: SigNoz alert rules + a notification channel are not yet configured (do this in the
    SigNoz UI), and there is no external uptime check for kdvmanager.nl itself.
-2. **Rate limiting**: `/telemetry/` is unauthenticated by design; an Envoy `local_ratelimit` on that
-   route is recommended.
-3. **Retention**: set explicitly in SigNoz (Settings → General); ClickHouse disk is small (5Gi).
-4. **Business metrics**: the per-service meters currently only count errors — domain metrics
+2. **Retention**: set explicitly in SigNoz (Settings → General); ClickHouse disk is small (5Gi).
+3. **Business metrics**: the per-service meters currently only count errors — domain metrics
    (schedules created, registrations, absences) belong there.
+4. **Pod log collection**: only OTLP app logs and Envoy stdout access logs are shipped; nginx/
+   RabbitMQ/ClickHouse pod logs are not. SigNoz's `k8s-infra` chart (DaemonSet) would add this and
+   replace the hand-rolled `kubeletstats`/`k8s_cluster` receivers.

--- a/src/Services/ApiGateways/Envoy/config/envoy.yaml
+++ b/src/Services/ApiGateways/Envoy/config/envoy.yaml
@@ -87,10 +87,37 @@ static_resources:
                 route:
                   prefix_rewrite: /
                   cluster: otel-collector-http
+                # Bounds the unauthenticated telemetry ingest per Envoy pod (60 burst / 30 rps).
+                typed_per_filter_config:
+                  envoy.filters.http.local_ratelimit:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                    stat_prefix: telemetry_rate_limiter
+                    token_bucket:
+                      max_tokens: 60
+                      tokens_per_fill: 30
+                      fill_interval: 1s
+                    filter_enabled:
+                      runtime_key: telemetry_rate_limit_enabled
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    filter_enforced:
+                      runtime_key: telemetry_rate_limit_enforced
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    status:
+                      code: TooManyRequests
           http_filters:
           - name: envoy.filters.http.cors
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+          # No-op at the listener level (no token_bucket): rate limiting only
+          # applies where a route sets typed_per_filter_config (telemetry).
+          - name: envoy.filters.http.local_ratelimit
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              stat_prefix: http_local_rate_limiter
           - name: envoy.filters.http.jwt_authn
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication

--- a/src/Shared/KDVManager.Shared.Infrastructure/Auth/AuthenticationExtensions.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Auth/AuthenticationExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 
 namespace KDVManager.Shared.Infrastructure.Auth;
@@ -39,6 +40,20 @@ public static class AuthenticationExtensions
                     ClockSkew = TimeSpan.FromMinutes(5),
                     RequireExpirationTime = true,
                     RequireSignedTokens = true
+                };
+
+                options.Events = new JwtBearerEvents
+                {
+                    // Surface why a token was rejected (expired, bad issuer, ...) without
+                    // logging the token itself.
+                    OnAuthenticationFailed = context =>
+                    {
+                        var logger = context.HttpContext.RequestServices
+                            .GetRequiredService<ILoggerFactory>()
+                            .CreateLogger("JwtAuthentication");
+                        logger.LogWarning(context.Exception, "JWT authentication failed for {RequestPath}", context.HttpContext.Request.Path);
+                        return Task.CompletedTask;
+                    }
                 };
             });
 

--- a/src/Shared/KDVManager.Shared.Infrastructure/Auth/AuthenticationExtensions.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Auth/AuthenticationExtensions.cs
@@ -51,7 +51,8 @@ public static class AuthenticationExtensions
                         var logger = context.HttpContext.RequestServices
                             .GetRequiredService<ILoggerFactory>()
                             .CreateLogger("JwtAuthentication");
-                        logger.LogWarning(context.Exception, "JWT authentication failed for {RequestPath}", context.HttpContext.Request.Path);
+                        logger.LogWarning(context.Exception, "JWT authentication failed for {RequestPath}",
+                            SanitizeForLog(context.HttpContext.Request.Path.Value));
                         return Task.CompletedTask;
                     }
                 };
@@ -66,5 +67,16 @@ public static class AuthenticationExtensions
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// The request path is user input: strip CR/LF so a crafted path cannot forge log
+    /// entries, and cap the length to keep abuse out of the log volume.
+    /// </summary>
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var sanitized = value.Replace("\r", "").Replace("\n", "");
+        return sanitized.Length <= 200 ? sanitized : sanitized[..200];
     }
 }

--- a/src/Shared/KDVManager.Shared.Infrastructure/Telemetry/TelemetryExtensions.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Telemetry/TelemetryExtensions.cs
@@ -2,6 +2,7 @@ using MassTransit.Logging;
 using MassTransit.Monitoring;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Npgsql;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -24,6 +25,10 @@ public static class TelemetryExtensions
     {
         var otelEndpoint = configuration[OtelEndpointConfigKey]
                            ?? Environment.GetEnvironmentVariable(OtelEndpointEnvKey);
+
+        // Enriches every span with tenant.id; resolved from DI so it shares the
+        // AsyncLocal-backed ITenancyContextAccessor with the tenancy middleware/filters.
+        services.TryAddSingleton<TenantEnrichmentProcessor>();
 
         var otel = services.AddOpenTelemetry();
 
@@ -61,7 +66,8 @@ public static class TelemetryExtensions
                     };
                 })
                 .AddSource(DiagnosticHeaders.DefaultListenerName)
-                .AddNpgsql();
+                .AddNpgsql()
+                .AddProcessor<TenantEnrichmentProcessor>();
 
             if (!string.IsNullOrWhiteSpace(otelEndpoint))
             {
@@ -78,6 +84,7 @@ public static class TelemetryExtensions
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddRuntimeInstrumentation()
+                .AddNpgsqlInstrumentation()
                 .AddMeter(InstrumentationOptions.MeterName);
 
             foreach (var meterName in additionalMeterNames)
@@ -103,7 +110,7 @@ public static class TelemetryExtensions
         if (ratio is null)
         {
             var envRatio = Environment.GetEnvironmentVariable(SamplingRatioEnvKey);
-            if (double.TryParse(envRatio, out var parsed)) ratio = parsed;
+            if (double.TryParse(envRatio, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsed)) ratio = parsed;
         }
         ratio ??= 1.0d;
         return Math.Clamp(ratio.Value, 0d, 1d);

--- a/src/Shared/KDVManager.Shared.Infrastructure/Telemetry/TenantEnrichmentProcessor.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Telemetry/TenantEnrichmentProcessor.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using KDVManager.Shared.Contracts.Tenancy;
+using OpenTelemetry;
+
+namespace KDVManager.Shared.Infrastructure.Telemetry;
+
+/// <summary>
+/// Stamps tenant.id on every span started while a tenant context is resolved, so child
+/// spans (database, HttpClient, MassTransit publish) carry the tenant like the server span.
+/// </summary>
+public class TenantEnrichmentProcessor : BaseProcessor<Activity>
+{
+    private readonly ITenancyContextAccessor _tenancyContextAccessor;
+
+    public TenantEnrichmentProcessor(ITenancyContextAccessor tenancyContextAccessor)
+    {
+        _tenancyContextAccessor = tenancyContextAccessor;
+    }
+
+    public override void OnStart(Activity data)
+    {
+        // No tenant is expected for spans outside a tenant flow (health checks, startup).
+        if (_tenancyContextAccessor.HasTenant)
+        {
+            data.SetTag("tenant.id", _tenancyContextAccessor.Current!.TenantId.ToString());
+        }
+    }
+}

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyContextAccessor.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyContextAccessor.cs
@@ -4,13 +4,16 @@ namespace KDVManager.Shared.Infrastructure.Tenancy;
 
 public class TenancyContextAccessor : ITenancyContextAccessor
 {
-    private ITenancyContext? _current;
+    // AsyncLocal flows the tenant context with the ambient execution context, so a single
+    // singleton instance serves HTTP requests and MassTransit consumers concurrently and
+    // can be read by singleton OTel processors without capturing a request scope.
+    private static readonly AsyncLocal<ITenancyContext?> _current = new();
 
     public ITenancyContext? Current
     {
-        get => _current ?? throw new TenantRequiredException();
-        set => _current = value;
+        get => _current.Value ?? throw new TenantRequiredException();
+        set => _current.Value = value;
     }
 
-    public bool HasTenant => _current != null;
+    public bool HasTenant => _current.Value != null;
 }

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyContextAccessor.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyContextAccessor.cs
@@ -7,7 +7,7 @@ public class TenancyContextAccessor : ITenancyContextAccessor
     // AsyncLocal flows the tenant context with the ambient execution context, so a single
     // singleton instance serves HTTP requests and MassTransit consumers concurrently and
     // can be read by singleton OTel processors without capturing a request scope.
-    private static readonly AsyncLocal<ITenancyContext?> _current = new();
+    private readonly AsyncLocal<ITenancyContext?> _current = new();
 
     public ITenancyContext? Current
     {

--- a/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyExtensions.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/Tenancy/TenancyExtensions.cs
@@ -8,7 +8,9 @@ namespace KDVManager.Shared.Infrastructure.Tenancy
     {
         public static IServiceCollection AddTenancy(this IServiceCollection services)
         {
-            services.AddScoped<ITenancyContextAccessor, TenancyContextAccessor>();
+            // Singleton because the accessor is AsyncLocal-backed: one instance safely serves
+            // all requests/consumers and can be injected into singleton OTel processors.
+            services.AddSingleton<ITenancyContextAccessor, TenancyContextAccessor>();
             services.AddScoped<ITenancyResolver, JwtTenancyResolver>();
             return services;
         }


### PR DESCRIPTION
## Summary
This PR improves observability and security by enriching telemetry with tenant context, adding rate limiting to telemetry ingestion, and enhancing Kubernetes pod attribution in the OpenTelemetry collector.

## Key Changes

### Telemetry Enrichment
- **New `TenantEnrichmentProcessor`**: Automatically stamps `tenant.id` on every span started within a tenant context (HTTP requests, MassTransit consumers), ensuring child spans (database, HTTP, messaging) carry tenant information without manual instrumentation
- **AsyncLocal-backed `TenancyContextAccessor`**: Changed from instance field to `AsyncLocal<T>` to safely flow tenant context across async boundaries and enable injection into singleton OTel processors
- **Tenancy registration**: Changed from scoped to singleton registration to support singleton OTel processors while maintaining correct async context flow

### Rate Limiting
- **Envoy telemetry route protection**: Added `local_ratelimit` filter to `/telemetry/` routes (both k8s and local configs) limiting unauthenticated browser telemetry to 30 rps with 60-token burst per Envoy pod, returning 429 on excess
- **Listener-level no-op filter**: Added local_ratelimit filter at HTTP listener level (without token_bucket) to enable route-level overrides

### Kubernetes Attribution
- **k8sattributes processor**: Added to OTel collector to enrich traces/metrics/logs with pod/namespace/deployment/node metadata from Kubernetes API
- **Memory limiter tuning**: Reduced limit from 512 MiB to 400 MiB with 100 MiB spike allowance to prevent OOM-kill
- **Removed redundant env vars**: Cleaned up duplicate OTEL configuration from migrator deployments (already set globally)

### Additional Improvements
- **JWT authentication logging**: Added `JwtBearerEvents.OnAuthenticationFailed` handler to log JWT failures (expired, bad issuer, etc.) as warnings without exposing tokens
- **Npgsql metrics**: Added `AddNpgsqlInstrumentation()` to metrics pipeline for database connection pool monitoring
- **Sampling ratio parsing**: Fixed to use `InvariantCulture` for robust float parsing from environment variables
- **Documentation**: Updated observability setup guide with tenant enrichment, rate limiting, and pod log collection notes

## Implementation Details
- Tenant enrichment leverages the existing `ITenancyContextAccessor` already used by tenancy middleware, ensuring consistency
- Rate limiting is applied only to the telemetry route via `typed_per_filter_config`, leaving other routes unaffected
- AsyncLocal ensures tenant context flows correctly through async/await without capturing request scope, enabling singleton OTel processor injection

https://claude.ai/code/session_016MTR8yN95UFqJCW33w4Z1L