### PR TITLE
fix(e2e): stop production telemetry endpoint leaking into e2e web build

### DIFF
--- a/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
+++ b/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
@@ -34,7 +34,7 @@ static_resources:
                   allow_origin_string_match:
                   - safe_regex:
                       regex: ".*"
-                  allow_headers: content-type,authorization
+                  allow_headers: content-type,authorization,traceparent,tracestate
                   allow_methods: GET, POST, PUT, HEAD, OPTIONS, DELETE
                   expose_headers: x-Total
               routes:

--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -52,6 +52,10 @@ services:
         VITE_APP_AUTH0_DOMAIN: http://localhost:5300
         VITE_APP_AUTH0_CLIENT_ID: e2e-client
         VITE_API_BASE_URL: //localhost:5200
+        # compose merges build.args maps key-wise; without an explicit empty
+        # value the production telemetry endpoint from docker-compose.yml
+        # leaks into the e2e image
+        VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ""
     volumes:
       - ./web/nginx/nginx.e2e.conf:/etc/nginx/conf.d/default.conf:ro
     ports:


### PR DESCRIPTION
## Problem

The `e2e` workflow on `main` is red — 30 of 36 tests failing since [run 28818305027](https://github.com/LuukLabs/KDVManager/actions/runs/28818305027) (first failing commit `6f837ac5`, latest failure [run 28820807032](https://github.com/LuukLabs/KDVManager/actions/runs/28820807032)).

Root cause: docker compose merges `build.args` maps key-wise across `-f` files, so the e2e web image inherited `VITE_OTEL_EXPORTER_OTLP_ENDPOINT` from the production `docker-compose.yml`. That activated browser fetch instrumentation, which adds a `traceparent` header to cross-origin API calls — and the e2e Envoy CORS config did not allow that header, so every preflight failed and all data-driven tests timed out with "element(s) not found".

## Fix

- `src/docker-compose.e2e.yml`: explicitly set `VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ""` so the e2e web build disables telemetry (the app no-ops on an empty endpoint).
- `src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml`: allow `traceparent`/`tracestate` in CORS to match production.

Either guard alone is sufficient; both are applied for defense in depth.

## Verification

The identical diff already ran green on CI: [e2e run 28819807153](https://github.com/LuukLabs/KDVManager/actions/runs/28819807153) (36/36 passing). Also verified the merged compose config resolves the endpoint to an empty string with a current docker compose (`docker compose config`).