### PR TITLE
Fix Daily Summary reporting -1 supervisors when BKR ratio has no solution

### DIFF
--- a/src/Services/Scheduling/Application/Features/GroupSummary/Queries/GetGroupSummary/GetGroupSummaryQueryHandler.cs
+++ b/src/Services/Scheduling/Application/Features/GroupSummary/Queries/GetGroupSummary/GetGroupSummaryQueryHandler.cs
@@ -67,7 +67,12 @@ public class GetGroupSummaryQueryHandler
 
         timeBlocks = timeBlocks.OrderBy(tb => tb.StartTime).ToList();
 
-        var maxProfessionals = timeBlocks.Any() ? timeBlocks.Max(tb => tb.RequiredProfessionals) : 0;
+        // If any time block has no valid staffing ratio, the day as a whole is not satisfiable either
+        int? maxProfessionals = !timeBlocks.Any()
+            ? 0
+            : timeBlocks.Any(tb => tb.RequiredProfessionals is null)
+                ? null
+                : timeBlocks.Max(tb => tb.RequiredProfessionals);
 
         return new GroupSummaryVM
         {
@@ -146,7 +151,7 @@ public class GetGroupSummaryQueryHandler
             EndTime = end,
             TimeSlotName = timeSlotName,
             TotalChildren = totalChildren,
-            RequiredProfessionals = result.HasSolution ? result.Professionals : -1,
+            RequiredProfessionals = result.HasSolution ? result.Professionals : null,
             AgeGroups = ageGroups
         };
     }

--- a/src/Services/Scheduling/Application/Features/GroupSummary/Queries/GetGroupSummary/GroupSummaryVM.cs
+++ b/src/Services/Scheduling/Application/Features/GroupSummary/Queries/GetGroupSummary/GroupSummaryVM.cs
@@ -14,7 +14,7 @@ public class GroupSummaryVM
     public required List<TimeBlockSummary> TimeBlocks { get; set; } = new List<TimeBlockSummary>();
 
     // Null when no valid staffing ratio could be determined for any time block on this date
-    public int? RequiredProfessionals { get; set; } = 0;
+    public int? RequiredProfessionals { get; set; }
     public int NumberOfChildren { get; set; } = 0;
 }
 

--- a/src/Services/Scheduling/Application/Features/GroupSummary/Queries/GetGroupSummary/GroupSummaryVM.cs
+++ b/src/Services/Scheduling/Application/Features/GroupSummary/Queries/GetGroupSummary/GroupSummaryVM.cs
@@ -13,7 +13,8 @@ public class GroupSummaryVM
     [Required]
     public required List<TimeBlockSummary> TimeBlocks { get; set; } = new List<TimeBlockSummary>();
 
-    public int RequiredProfessionals { get; set; } = 0;
+    // Null when no valid staffing ratio could be determined for any time block on this date
+    public int? RequiredProfessionals { get; set; } = 0;
     public int NumberOfChildren { get; set; } = 0;
 }
 
@@ -23,7 +24,8 @@ public class TimeBlockSummary
     public required TimeOnly EndTime { get; set; }
     public required string TimeSlotName { get; set; } = string.Empty;
     public required int TotalChildren { get; set; }
-    public required int RequiredProfessionals { get; set; } = 0;
+    // Null when the BKR calculator found no valid staffing ratio for this time block
+    public int? RequiredProfessionals { get; set; }
     public required List<AgeGroupSummary> AgeGroups { get; set; } = new List<AgeGroupSummary>();
 }
 

--- a/src/web/src/api/scheduling/models/groupSummaryVM.ts
+++ b/src/web/src/api/scheduling/models/groupSummaryVM.ts
@@ -12,6 +12,7 @@ export type GroupSummaryVM = {
   groupName: string | null;
   date: string;
   timeBlocks: TimeBlockSummary[];
-  requiredProfessionals?: number;
+  /** @nullable */
+  requiredProfessionals?: number | null;
   numberOfChildren?: number;
 };

--- a/src/web/src/api/scheduling/models/timeBlockSummary.ts
+++ b/src/web/src/api/scheduling/models/timeBlockSummary.ts
@@ -12,7 +12,8 @@ export type TimeBlockSummary = {
   /** @nullable */
   timeSlotName: string | null;
   totalChildren: number;
-  requiredProfessionals: number;
+  /** @nullable */
+  requiredProfessionals: number | null;
   /** @nullable */
   ageGroups: AgeGroupSummary[] | null;
 };

--- a/src/web/src/components/GroupSummary.tsx
+++ b/src/web/src/components/GroupSummary.tsx
@@ -217,9 +217,13 @@ const GroupSummary = ({ groupId, selectedDate, absentCount = 0 }: GroupSummaryPr
             )}
             <Chip
               icon={<SupervisorAccount />}
-              label={`${summary.requiredProfessionals} ${t("supervisors")}`}
+              label={
+                summary.requiredProfessionals != null
+                  ? `${summary.requiredProfessionals} ${t("supervisors")}`
+                  : t("Ratio requirement cannot be met")
+              }
               size="small"
-              color="secondary"
+              color={summary.requiredProfessionals != null ? "secondary" : "error"}
               variant="outlined"
               sx={{ fontWeight: 600 }}
             />
@@ -283,12 +287,12 @@ const GroupSummary = ({ groupId, selectedDate, absentCount = 0 }: GroupSummaryPr
                         display: "flex",
                         alignItems: "center",
                         gap: 0.5,
-                        color: "warning.main",
+                        color: block.requiredProfessionals != null ? "warning.main" : "error.main",
                         fontWeight: 500,
                       }}
                     >
                       <SupervisorAccount sx={{ fontSize: 12 }} />
-                      {block.requiredProfessionals}
+                      {block.requiredProfessionals ?? t("Ratio requirement cannot be met")}
                     </Typography>
                   </Box>
                 </Box>
@@ -364,8 +368,12 @@ const GroupSummary = ({ groupId, selectedDate, absentCount = 0 }: GroupSummaryPr
                 />
                 <Chip
                   icon={<SupervisorAccount />}
-                  label={`${selectedTimeBlock?.requiredProfessionals} ${t("supervisors needed")}`}
-                  color="secondary"
+                  label={
+                    selectedTimeBlock?.requiredProfessionals != null
+                      ? `${selectedTimeBlock.requiredProfessionals} ${t("supervisors needed")}`
+                      : t("Ratio requirement cannot be met")
+                  }
+                  color={selectedTimeBlock?.requiredProfessionals != null ? "secondary" : "error"}
                   variant="outlined"
                 />
               </Box>

--- a/src/web/src/locales/en/translation.json
+++ b/src/web/src/locales/en/translation.json
@@ -337,6 +337,7 @@
   "Primary contact": "Primary contact",
   "Emergency contact": "Emergency contact",
   "DOB": "DOB",
+  "Ratio requirement cannot be met": "Ratio requirement cannot be met",
   "Reason": "Reason",
   "Redirecting to login...": "Redirecting to login...",
   "Relationship Details": "Relationship Details",

--- a/src/web/src/locales/nl/translation.json
+++ b/src/web/src/locales/nl/translation.json
@@ -337,6 +337,7 @@
   "Primary contact": "Primair contact",
   "Emergency contact": "Noodcontact",
   "DOB": "Geb.",
+  "Ratio requirement cannot be met": "BKR-verhouding niet haalbaar",
   "Reason": "Reden",
   "Redirecting to login...": "Doorverwijzen naar inloggen...",
   "Relationship Details": "Relatiegegevens",


### PR DESCRIPTION
GetGroupSummaryQueryHandler used -1 as a sentinel for "no valid
staffing ratio found", which leaked straight into the UI as a literal
negative supervisor count. RequiredProfessionals is now nullable end
to end, and the frontend shows a "ratio requirement cannot be met"
state instead of a raw number.