### PR TITLE
Add safety net to detect uncovered files in merge-gate workflow

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -5,6 +5,13 @@ name: merge-gate
 # don't report a check run, so they don't block. Mark only the "all-checks"
 # job as a required status check in branch protection.
 #
+# Safety net: if a PR ends up with zero other check runs (its diff didn't
+# match any workflow's paths filter), that usually means a change landed in a
+# spot no workflow covers rather than that the PR was genuinely CI-exempt.
+# Fail in that case unless every changed file matches noCiNeededPatterns
+# below, so gaps in path-filter coverage get noticed instead of silently
+# merging untested.
+#
 # Note: if you re-run a failed workflow and it passes, re-run this gate too so
 # it picks up the new conclusion.
 
@@ -15,6 +22,7 @@ on:
 
 permissions:
   checks: read
+  pull-requests: read
 
 jobs:
   all-checks:
@@ -33,6 +41,16 @@ jobs:
           const pollIntervalMs = 30_000;
           const timeoutMs = 55 * 60_000;
           const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          // Files that never need a CI check of their own. Keep this list
+          // narrow and explicit rather than guessing what's "safe".
+          const noCiNeededPatterns = [
+            /\.md$/i,
+            /^LICENSE$/,
+            /^\.gitignore$/,
+            /^\.editorconfig$/,
+            /^docs\//,
+          ];
 
           // Give sibling workflows triggered by the same event time to
           // register their check runs before the first poll.
@@ -56,6 +74,24 @@ jobs:
 
             const pending = others.filter((run) => run.status !== 'completed');
             if (pending.length === 0) {
+              if (others.length === 0) {
+                const files = await github.paginate(github.rest.pulls.listFiles, {
+                  ...context.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                });
+                const uncovered = files.filter(
+                  (f) => !noCiNeededPatterns.some((pattern) => pattern.test(f.filename))
+                );
+                if (uncovered.length > 0) {
+                  core.setFailed(
+                    'No other check ran for this PR, and these changed files are not covered by ' +
+                    `any workflow's paths filter or the no-CI-needed allowlist: ${uncovered.map((f) => f.filename).join(', ')}. ` +
+                    "Extend the relevant workflow's paths (or this file's noCiNeededPatterns if the files are truly inert)."
+                  );
+                  return;
+                }
+              }
               core.info(`All ${others.length} other checks completed successfully or were skipped.`);
               return;
             }


### PR DESCRIPTION
## Summary
This PR adds a safety net to the merge-gate workflow to catch cases where PR changes aren't covered by any workflow's path filters, preventing untested code from silently merging.

## Key Changes
- Added `pull-requests: read` permission to allow fetching PR file lists
- Implemented detection for PRs with zero check runs (indicating no workflow path filters matched)
- Created an allowlist (`noCiNeededPatterns`) of file patterns that genuinely don't need CI checks (markdown, license, config files, docs)
- When a PR has no other checks and contains files outside the allowlist, the merge-gate job now fails with a descriptive error message
- Error message guides users to either extend workflow path filters or add files to the allowlist if they're truly inert

## Implementation Details
- The safety net only triggers when `others.length === 0`, indicating no sibling workflows registered check runs
- Uses GitHub API pagination to fetch all changed files in the PR
- Filters changed files against the `noCiNeededPatterns` regex patterns
- Fails with a clear message listing uncovered files and suggesting remediation steps
- The allowlist is intentionally narrow and explicit to avoid false negatives

https://claude.ai/code/session_011aEuvMih3sbh3HYNYWb3CY