### PR TITLE
fix(docker): stop migrator rebuilds from redownloading dotnet-ef tool

### DIFF
--- a/src/Services/CRM/Infrastructure/Dockerfile
+++ b/src/Services/CRM/Infrastructure/Dockerfile
@@ -16,7 +16,12 @@ COPY ["Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.
 
 RUN dotnet restore "Services/CRM/Api/Api.csproj"
 
-FROM restore AS build
+FROM restore AS ef-tool
+
+RUN dotnet tool install -g dotnet-ef --version 10.0.9
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+FROM ef-tool AS build
 
 COPY Services/CRM Services/CRM
 COPY Shared Shared
@@ -25,8 +30,6 @@ WORKDIR "/src/Services/CRM"
 
 FROM build AS build-migrator
 
-RUN dotnet tool install -g dotnet-ef --version 10.0.9
-ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet ef migrations bundle --self-contained -r linux-x64 --startup-project "./Api"
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.9 AS migrator-runtime

--- a/src/Services/Scheduling/Infrastructure/Dockerfile
+++ b/src/Services/Scheduling/Infrastructure/Dockerfile
@@ -16,7 +16,12 @@ RUN --mount=type=secret,id=nuget_github_token \
 
 RUN dotnet restore "Services/Scheduling/Api/Api.csproj"
 
-FROM restore AS build
+FROM restore AS ef-tool
+
+RUN dotnet tool install -g dotnet-ef --version 10.0.9
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+FROM ef-tool AS build
 
 COPY Services/Scheduling Services/Scheduling
 COPY Shared Shared
@@ -25,8 +30,6 @@ WORKDIR "/src/Services/Scheduling"
 
 FROM build AS build-migrator
 
-RUN dotnet tool install -g dotnet-ef --version 10.0.9
-ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet ef migrations bundle --self-contained -r linux-x64 --project ./Infrastructure --startup-project ./Api
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.9 AS migrator-runtime


### PR DESCRIPTION
## Summary
- `docker compose up --build` was reinstalling the `dotnet-ef` tool (a slow network fetch) on every rebuild of `crm-migrator`/`scheduling-migrator`, even when nothing under `Infrastructure`/`Migrations` had changed.
- Root cause: `RUN dotnet tool install -g dotnet-ef` sat right after the `COPY Services/<X> Services/<X>` layer. Any unrelated source change anywhere in the service (an unrelated API controller edit, for example) invalidated that COPY layer, which cascaded into invalidating the tool install too.
- Fix: split the tool install into its own stage sandwiched between `restore` and the source `COPY`, so it only depends on the csproj/restore layer. Now it stays cached across unrelated source changes; only the `dotnet ef migrations bundle` step (which genuinely needs the fresh source) reruns.

## Test plan
- [x] Built `crm-migrator` from a clean cache, then touched an unrelated file in `Services/CRM/Api/Program.cs` and rebuilt — confirmed `[ef-tool] RUN dotnet tool install -g dotnet-ef` showed `CACHED` while only the bundle step reran (160s vs. 372s cold, no tool re-download).
- [x] Built `scheduling-migrator` end-to-end to confirm the equivalent Dockerfile still builds cleanly with the NuGet secret mount.