### PR TITLE
Shorten child number column header to #

### DIFF
--- a/src/web/src/features/children/ChildrenTable.tsx
+++ b/src/web/src/features/children/ChildrenTable.tsx
@@ -95,8 +95,8 @@ export const ChildrenTable = () => {
     () => [
       staticColumn({
         field: "childNumber",
-        headerName: t("table.header.childNumber"),
-        width: 100,
+        headerName: t("#"),
+        width: 60,
       }),
       staticColumn({
         field: "fullName",

--- a/src/web/src/locales/en/translation.json
+++ b/src/web/src/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  "#": "#",
   "0-1 years": "0-1 years",
   "1-2 years": "1-2 years",
   "2-3 years": "2-3 years",

--- a/src/web/src/locales/nl/translation.json
+++ b/src/web/src/locales/nl/translation.json
@@ -1,4 +1,5 @@
 {
+  "#": "#",
   "0-1 years": "0-1 jaar",
   "1-2 years": "1-2 jaar",
   "2-3 years": "2-3 jaar",


### PR DESCRIPTION
## Summary
- The children table's first column ("Child Number") now shows just "#" in the header, and the column width is narrowed from 100px to 60px to match.
- The full "Child Number" label is unchanged on the mobile card view, where it's shown as a labeled line ("Child Number: 123") rather than a column header.

## Test plan
- [x] `tsc --noEmit`
- [x] `eslint`
- [x] `vitest run` (all existing unit tests pass, including ChildrenTable.test.tsx)