### PR TITLE
fix(web): supervisor chip color, details spacing & header avatar contrast

### DIFF
--- a/src/web/src/components/TimeBlockDetailsDialog.tsx
+++ b/src/web/src/components/TimeBlockDetailsDialog.tsx
@@ -165,7 +165,7 @@ const TimeBlockDetailsDialog = ({ timeBlock, onClose }: TimeBlockDetailsDialogPr
             </Typography>
           </DialogTitle>
 
-          <DialogContent sx={{ px: 3, pt: 2, pb: 3 }}>
+          <DialogContent sx={{ px: 3, pt: 3, pb: 3 }}>
             <Box sx={{ mb: 2 }}>
               <Box sx={{ display: "flex", gap: 1, mb: 2, flexWrap: "wrap" }}>
                 <Chip
@@ -181,7 +181,7 @@ const TimeBlockDetailsDialog = ({ timeBlock, onClose }: TimeBlockDetailsDialogPr
                       ? `${timeBlock.requiredProfessionals} ${t("supervisors needed")}`
                       : t("Ratio requirement cannot be met")
                   }
-                  color={timeBlock.requiredProfessionals != null ? "secondary" : "error"}
+                  color={timeBlock.requiredProfessionals != null ? "info" : "error"}
                   variant="outlined"
                 />
               </Box>

--- a/src/web/src/components/child/ChildHeader.tsx
+++ b/src/web/src/components/child/ChildHeader.tsx
@@ -164,11 +164,12 @@ export const ChildHeader: React.FC<ChildHeaderProps> = ({
               sx={{
                 width: { xs: 56, md: 64 },
                 height: { xs: 56, md: 64 },
-                bgcolor: alpha("#fff", 0.22),
+                bgcolor: "common.white",
                 color: "primary.main",
                 fontSize: { xs: "1.35rem", md: "1.5rem" },
                 fontWeight: "bold",
-                border: "2px solid rgba(255,255,255,0.3)",
+                border: "2px solid rgba(255,255,255,0.6)",
+                boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
               }}
             >
               {loading ? <PersonIcon /> : getInitials()}

--- a/src/web/src/components/guardian/GuardianHeader.tsx
+++ b/src/web/src/components/guardian/GuardianHeader.tsx
@@ -89,11 +89,12 @@ export const GuardianHeader: React.FC<GuardianHeaderProps> = ({
               sx={{
                 width: { xs: 56, md: 64 },
                 height: { xs: 56, md: 64 },
-                bgcolor: alpha("#fff", 0.25),
+                bgcolor: "common.white",
                 color: "secondary.main",
                 fontSize: { xs: "1.35rem", md: "1.5rem" },
                 fontWeight: "bold",
-                border: "2px solid rgba(255,255,255,0.3)",
+                border: "2px solid rgba(255,255,255,0.6)",
+                boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
               }}
             >
               {loading ? <PersonIcon /> : initials.toUpperCase()}

--- a/src/web/src/features/children/ChildrenTable.test.tsx
+++ b/src/web/src/features/children/ChildrenTable.test.tsx
@@ -87,6 +87,9 @@ describe("ChildrenTable — record navigation (browser)", () => {
     // the tap in the next test (failure screenshots show the dialog still
     // open on top of the mobile card list).
     await userEvent.click(page.getByRole("button", { name: "Cancel" }));
+    // The dialog closes with a transition and then unmounts, so the element is
+    // removed from the DOM. Assert absence rather than invisibility: a missing
+    // element has no visibility to evaluate, which is what made this flaky.
     await expect.element(page.getByText("Remove child 'Jane Doe'")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
UI polish on the scheduling details dialog and the child/guardian detail headers.

**Time block details dialog** (`TimeBlockDetailsDialog`)
- Added top spacing between the header and the chip row (`pt: 2` → `pt: 3`).
- Changed the supervisor chip color from `secondary` (terracotta, reads as a warning) to `info` (teal).

**Child & guardian headers** (`ChildHeader`, `GuardianHeader`)
- Avatar was translucent white on a same-color gradient (teal-on-teal), hard to see. Now solid white with the colored initials, plus a stronger border and a soft shadow for contrast.