### PR TITLE
test(e2e): consolidated axe HTML accessibility report

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,15 @@ jobs:
         if-no-files-found: ignore
         retention-days: 14
 
+    - name: Upload accessibility report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: a11y-report
+        path: tests/e2e/a11y-report
+        if-no-files-found: ignore
+        retention-days: 14
+
     - name: Collect stack logs
       if: failure()
       working-directory: ./src

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ autom4te.cache/
 tarballs/
 test-results/
 playwright-report/
+a11y-report/
 
 # Mac bundle stuff
 *.dmg

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -63,6 +63,16 @@ app is a production build, MUI strips icon `data-testid`s — accessible names
 must come from real `aria-label`s/tooltips/text, which is exactly what these
 scans verify.
 
+### Consolidated report
+
+After the scans run, an `afterAll` hook writes a single
+[`axe-html-reporter`](https://www.npmjs.com/package/axe-html-reporter) HTML
+report to `tests/e2e/a11y-report/index.html` (git-ignored) covering every
+scanned view. It merges **violations** and **"needs review"** (`incomplete`)
+findings — the latter includes contrast checks axe could not decide
+automatically, so review those manually. The report is produced even when the
+run passes, and CI uploads it as the `a11y-report` artifact.
+
 Note: the e2e compose file gives postgres **no volume** — `docker compose
 ... down` discards all data, which keeps runs reproducible. Don't combine
 `docker-compose.e2e.yml` with `docker-compose.override.yml` (the dev

--- a/tests/e2e/helpers/a11y.ts
+++ b/tests/e2e/helpers/a11y.ts
@@ -1,6 +1,13 @@
 import { AxeBuilder } from "@axe-core/playwright";
 import { expect, type Page, type TestInfo } from "@playwright/test";
-import type { Result } from "axe-core";
+import type { AxeResults, Result } from "axe-core";
+import { createHtmlReport } from "axe-html-reporter";
+
+/** Per-view axe results collected during a run, keyed by label (retries overwrite). */
+const collectedResults = new Map<string, AxeResults>();
+
+/** Where the consolidated HTML report is written (relative to tests/e2e). */
+export const A11Y_REPORT_DIR = "a11y-report";
 
 /**
  * WCAG conformance the scans target. axe maps roughly half of WCAG's success
@@ -52,6 +59,9 @@ export async function expectNoWcagViolations(
   const results = await builder.analyze();
   const violations = results.violations;
 
+  // Collect for the consolidated HTML report (written in writeA11yReport()).
+  collectedResults.set(label, results);
+
   // Always attach the full report so moderate/minor findings are reviewable.
   if (violations.length > 0) {
     await testInfo.attach(`axe-${label}.json`, {
@@ -72,4 +82,46 @@ export async function expectNoWcagViolations(
           blocking.map(formatViolation).join("\n\n")
       : undefined,
   ).toEqual([]);
+}
+
+/** Tag each finding's help text with the view it came from, for the merged report. */
+function tagByView(label: string, findings: Result[] = []): Result[] {
+  return findings.map((f) => ({ ...f, help: `[${label}] ${f.help}` }));
+}
+
+/**
+ * Write one consolidated axe HTML report (via axe-html-reporter) covering every
+ * view scanned this run, into A11Y_REPORT_DIR. Call it from an afterAll hook so
+ * it runs even when some scans fail. Merges violations and "incomplete" (needs
+ * manual review — e.g. contrast axe could not decide) across views, and lists a
+ * per-view count in the summary. Returns the report path, or undefined if no
+ * scan ran.
+ */
+export function writeA11yReport(): string | undefined {
+  if (collectedResults.size === 0) return undefined;
+
+  const views = [...collectedResults.entries()];
+  const violations = views.flatMap(([label, r]) => tagByView(label, r.violations));
+  const incomplete = views.flatMap(([label, r]) => tagByView(label, r.incomplete));
+
+  const perView = views
+    .map(
+      ([label, r]) =>
+        `${label}: ${r.violations.length} violations, ${(r.incomplete ?? []).length} needs review`,
+    )
+    .join("<br/>");
+
+  createHtmlReport({
+    results: { violations, incomplete },
+    options: {
+      projectKey: "KDVManager",
+      reportFileName: "index.html",
+      outputDir: A11Y_REPORT_DIR,
+      customSummary:
+        `WCAG 2.1 A/AA scan · ${views.length} views · gate blocks serious/critical.<br/>` +
+        `"needs review" items (incl. some contrast checks) are not gated — review manually.<br/><br/>` +
+        perView,
+    },
+  });
+  return `${A11Y_REPORT_DIR}/index.html`;
 }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -15,6 +15,7 @@
     "@playwright/test": "^1.57.0",
     "@types/node": "^24.10.1",
     "axe-core": "^4.12.1",
+    "axe-html-reporter": "^2.2.11",
     "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@11.0.8"

--- a/tests/e2e/pnpm-lock.yaml
+++ b/tests/e2e/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       axe-core:
         specifier: ^4.12.1
         version: 4.12.1
+      axe-html-reporter:
+        specifier: ^2.2.11
+        version: 2.2.11(axe-core@4.12.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -43,10 +46,20 @@ packages:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
+  axe-html-reporter@2.2.11:
+    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
+    engines: {node: '>=8.9.0'}
+    peerDependencies:
+      axe-core: '>=3'
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -83,8 +96,15 @@ snapshots:
 
   axe-core@4.12.1: {}
 
+  axe-html-reporter@2.2.11(axe-core@4.12.1):
+    dependencies:
+      axe-core: 4.12.1
+      mustache: 4.2.0
+
   fsevents@2.3.2:
     optional: true
+
+  mustache@4.2.0: {}
 
   playwright-core@1.60.0: {}
 

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -18,7 +18,7 @@
  */
 import { test } from "@playwright/test";
 import { gotoApp } from "../helpers/app";
-import { expectNoWcagViolations } from "../helpers/a11y";
+import { expectNoWcagViolations, writeA11yReport } from "../helpers/a11y";
 
 /** Top-level routes that render under MainLayout (all require auth). */
 const ROUTES: { path: string; label: string }[] = [
@@ -38,6 +38,12 @@ const ROUTES: { path: string; label: string }[] = [
 ];
 
 test.describe("accessibility (WCAG 2.1 A/AA)", () => {
+  // Emit one consolidated axe HTML report after all scans (runs even on failure).
+  test.afterAll(() => {
+    const reportPath = writeA11yReport();
+    if (reportPath) console.log(`Accessibility report written: tests/e2e/${reportPath}`);
+  });
+
   for (const { path, label } of ROUTES) {
     test(`no serious/critical violations on ${path}`, async ({ page }, testInfo) => {
       await gotoApp(page, path);


### PR DESCRIPTION
## What

Follow-up to the WCAG work in #811 (now merged). Adds a **consolidated accessibility report** using [`axe-html-reporter`](https://www.npmjs.com/package/axe-html-reporter).

- The a11y scans now collect each view's axe results; an `afterAll` hook writes **one** HTML report (`tests/e2e/a11y-report/index.html`) covering every scanned view.
- The report merges **violations** and **"needs review"** (`incomplete`) findings — the latter includes contrast checks axe couldn't decide automatically — with a per-view count in the summary.
- Produced even when the run passes; the output dir is git-ignored and CI uploads it as the `a11y-report` artifact.

## Files

- `tests/e2e/helpers/a11y.ts` — collect `AxeResults` per view; new `writeA11yReport()`.
- `tests/e2e/specs/a11y.spec.ts` — `afterAll` calls `writeA11yReport()`.
- `.github/workflows/e2e.yml` — upload the `a11y-report` artifact.
- `.gitignore` — ignore `a11y-report/`.
- `tests/e2e/README.md` — document it.

## Verification

- `tsc --noEmit` clean; `playwright test --list` collects all 14 a11y scans.
- Smoke-tested `createHtmlReport` with synthetic axe results locally — writes a valid ~10 KB HTML file.