### PR TITLE
fix(web): child detail mobile layout (guardians card last, Link Guardian button fits)

### DIFF
--- a/src/web/src/features/guardians/ChildGuardiansCard.tsx
+++ b/src/web/src/features/guardians/ChildGuardiansCard.tsx
@@ -93,13 +93,14 @@ export const ChildGuardiansCard = ({
 
   const loading = isLoading || externalLoading;
 
-  const cardActions = (
+  const renderLinkButton = (fullWidth: boolean) => (
     <Button
       variant="outlined"
       startIcon={<Add fontSize="small" />}
       onClick={() => setLinkDialogOpen(true)}
       size={isMobile ? "medium" : "small"}
       disabled={loading}
+      fullWidth={fullWidth}
       sx={{
         minHeight: { xs: 44, md: "auto" },
         fontWeight: 600,
@@ -116,9 +117,12 @@ export const ChildGuardiansCard = ({
         title={t("Guardians")}
         description={t("People authorized to pick up or be contacted about this child.")}
         icon={<PeopleIcon color="primary" />}
-        actions={cardActions}
+        // On mobile the header row has no room for the text button next to the
+        // title/description, so show it full-width at the top of the card body.
+        actions={isMobile ? undefined : renderLinkButton(false)}
         collapsible={false}
       >
+        {isMobile && <Box sx={{ mb: 2 }}>{renderLinkButton(true)}</Box>}
         {loading ? (
           <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
             <CircularProgress size={24} />

--- a/src/web/src/pages/children/tabs/GeneralInformationTab.tsx
+++ b/src/web/src/pages/children/tabs/GeneralInformationTab.tsx
@@ -201,13 +201,15 @@ export const GeneralInformationTab: React.FC<GeneralInformationTabProps> = ({ ch
           />
         </Grid>
 
-        {/* Guardians Information */}
-        <Grid size={{ xs: 12, lg: 6 }}>
+        {/* Guardians Information. On mobile the cards stack in one column, so
+            order guardians last (after medical); on lg it keeps its spot in the
+            right column beside basic information. */}
+        <Grid size={{ xs: 12, lg: 6 }} sx={{ order: { xs: 3, lg: 2 } }}>
           {child.id && <ChildGuardiansCard childId={child.id} />}
         </Grid>
 
         {/* Medical / Extra Information */}
-        <Grid size={{ xs: 12, lg: 6 }}>
+        <Grid size={{ xs: 12, lg: 6 }} sx={{ order: { xs: 2, lg: 3 } }}>
           <MedicalInformationCard
             allergies={child.allergies}
             medication={child.medication}

--- a/src/web/src/pages/children/tabs/PlanningTab.tsx
+++ b/src/web/src/pages/children/tabs/PlanningTab.tsx
@@ -27,14 +27,18 @@ type SectionHeaderProps = {
 // primary action(s) on the right. Keeping this in one place is what makes
 // "Add Schedule / Add End Mark" and "Add Absence" read as the same pattern.
 const SectionHeader: React.FC<SectionHeaderProps> = ({ icon, title, actions }) => (
+  // Stack the title and the (full-width) action buttons in a column until md.
+  // The buttons are fullWidth/large while isMobile (down "md"), so switching to
+  // a row any earlier (e.g. at sm) forces a full-width button onto the title
+  // row and it overflows the panel.
   <Box
     sx={{
       display: "flex",
-      alignItems: { xs: "flex-start", sm: "center" },
+      alignItems: { xs: "flex-start", md: "center" },
       justifyContent: "space-between",
       mb: { xs: 2, md: 3 },
-      flexDirection: { xs: "column", sm: "row" },
-      gap: { xs: 2, sm: 2 },
+      flexDirection: { xs: "column", md: "row" },
+      gap: 2,
     }}
   >
     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -44,9 +48,9 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ icon, title, actions }) =
       </Typography>
     </Box>
     <Stack
-      direction={{ xs: "column", sm: "row" }}
+      direction={{ xs: "column", md: "row" }}
       spacing={1}
-      sx={{ width: { xs: "100%", sm: "auto" } }}
+      sx={{ width: { xs: "100%", md: "auto" } }}
     >
       {actions}
     </Stack>

--- a/src/web/src/pages/children/tabs/PlanningTab.tsx
+++ b/src/web/src/pages/children/tabs/PlanningTab.tsx
@@ -27,18 +27,14 @@ type SectionHeaderProps = {
 // primary action(s) on the right. Keeping this in one place is what makes
 // "Add Schedule / Add End Mark" and "Add Absence" read as the same pattern.
 const SectionHeader: React.FC<SectionHeaderProps> = ({ icon, title, actions }) => (
-  // Stack the title and the (full-width) action buttons in a column until md.
-  // The buttons are fullWidth/large while isMobile (down "md"), so switching to
-  // a row any earlier (e.g. at sm) forces a full-width button onto the title
-  // row and it overflows the panel.
   <Box
     sx={{
       display: "flex",
-      alignItems: { xs: "flex-start", md: "center" },
+      alignItems: { xs: "flex-start", sm: "center" },
       justifyContent: "space-between",
       mb: { xs: 2, md: 3 },
-      flexDirection: { xs: "column", md: "row" },
-      gap: 2,
+      flexDirection: { xs: "column", sm: "row" },
+      gap: { xs: 2, sm: 2 },
     }}
   >
     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -48,9 +44,9 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({ icon, title, actions }) =
       </Typography>
     </Box>
     <Stack
-      direction={{ xs: "column", md: "row" }}
+      direction={{ xs: "column", sm: "row" }}
       spacing={1}
-      sx={{ width: { xs: "100%", md: "auto" } }}
+      sx={{ width: { xs: "100%", sm: "auto" } }}
     >
       {actions}
     </Stack>


### PR DESCRIPTION
## What

Two mobile-layout fixes on the **child detail** page (`/children/:id`).

### 1. General tab — guardians card at the bottom on mobile
The tab has three cards (basic, guardians, medical), each `lg:6`. On mobile they stack into one column in DOM order — basic → **guardians** → medical — leaving guardians in the middle. Added responsive `order` so guardians is last on `xs`, while keeping its right-column spot beside basic info on `lg` (desktop unchanged).

### 2. Guardians card — "Link Guardian" button didn't fit on mobile
The card header (`SectionHeader`) is a single row with a non-shrinking actions slot, so the text button "Voogd koppelen" crowds the title/description on narrow phones. On mobile the button is now rendered **full-width at the top of the card body**; on desktop it stays in the header as before.

## Notes
- CSS/responsive-only; no logic or API changes. Desktop layout unchanged.
- `tsc` and eslint clean.
- Not rendered in a live mobile viewport here (needs the full stack).