### PR TITLE
build: migrate scheduling OpenAPI to Microsoft package

### DIFF
--- a/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
+++ b/src/Services/ApiGateways/Envoy/config/envoy.e2e.yaml
@@ -78,7 +78,7 @@ static_resources:
               - match:
                   prefix: /crm/openapi/
               - match:
-                  prefix: /scheduling/swagger/
+                  prefix: /scheduling/openapi/
               - match:
                   prefix: /crm/
                 requires:

--- a/src/Services/ApiGateways/Envoy/config/envoy.yaml
+++ b/src/Services/ApiGateways/Envoy/config/envoy.yaml
@@ -142,7 +142,7 @@ static_resources:
               - match:
                   prefix: /crm/openapi/
               - match:
-                  prefix: /scheduling/swagger/
+                  prefix: /scheduling/openapi/
               # Telemetry ingest is unauthenticated: browser sessions have no
               # token before login and errors must be reportable regardless.
               - match:

--- a/src/Services/CRM/Api/Api.csproj
+++ b/src/Services/CRM/Api/Api.csproj
@@ -20,11 +20,6 @@
     <Folder Include="Middleware\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <!-- Direct reference to lift the transitive Microsoft.OpenApi above GHSA-v5pm-xwqc-g5wc.
-         Stay on the 2.x line: Microsoft.AspNetCore.OpenApi 10.0.9's XmlCommentGenerator
-         targets the 2.x object model and breaks (CS0200) against Microsoft.OpenApi 3.x. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">

--- a/src/Services/CRM/Api/ConfigureServices.cs
+++ b/src/Services/CRM/Api/ConfigureServices.cs
@@ -1,8 +1,8 @@
-using Microsoft.OpenApi;
 using KDVManager.Services.CRM.Api.Telemetry;
 using KDVManager.Services.CRM.Infrastructure;
 using KDVManager.Shared.Infrastructure.Auth;
 using KDVManager.Shared.Infrastructure.Http;
+using KDVManager.Shared.Infrastructure.OpenApi;
 using KDVManager.Shared.Infrastructure.Telemetry;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -18,59 +18,7 @@ public static class ConfigureServices
         services.AddHealthChecks()
             .AddDbContextCheck<ApplicationDbContext>("postgres", tags: ["ready"]);
 
-        services.AddOpenApi(options =>
-        {
-            options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0;
-
-            options.AddDocumentTransformer((document, context, cancellationToken) =>
-            {
-                document.Info = new()
-                {
-                    Title = "KDVManager CRM API",
-                    Version = "v1",
-                    Contact = new()
-                    {
-                        Name = "Luuk van Hulten",
-                        Email = "admin@kdvmanager.nl"
-                    }
-                };
-                return Task.CompletedTask;
-            });
-            options.AddSchemaTransformer((schema, context, cancellationToken) =>
-            {
-                if (schema.Properties != null)
-                {
-                    var newProperties = schema.Properties.ToDictionary(
-                        prop => Char.ToLowerInvariant(prop.Key[0]) + prop.Key.Substring(1),
-                        prop => prop.Value
-                    );
-                    schema.Properties = newProperties;
-                }
-                // ASP.NET Core 9 OpenAPI emits a `pattern` on integer fields and omits the `type`,
-                // which causes Orval to generate `unknown` instead of `number`. Fix both.
-                if (schema.Format == "int32" || schema.Format == "int64")
-                {
-                    schema.Pattern = null;
-                    schema.Type = JsonSchemaType.Integer;
-                }
-                return Task.CompletedTask;
-            });
-            options.AddOperationTransformer((operation, context, cancellationToken) =>
-            {
-                if (operation.Parameters != null)
-                {
-                    foreach (var parameter in operation.Parameters)
-                    {
-                        if (parameter is OpenApiParameter p && !string.IsNullOrEmpty(p.Name))
-                        {
-                            p.Name = Char.ToLowerInvariant(p.Name[0]) + p.Name[1..];
-                        }
-                    }
-                }
-
-                return Task.CompletedTask;
-            });
-        });
+        services.AddKdvManagerOpenApi("KDVManager CRM API");
 
         services.AddKdvManagerAuthentication(configuration);
 

--- a/src/Services/Scheduling/Api/Api.csproj
+++ b/src/Services/Scheduling/Api/Api.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <!-- Direct reference to lift the transitive Microsoft.OpenApi above GHSA-v5pm-xwqc-g5wc.
          Stay on the 2.x line: Microsoft.AspNetCore.OpenApi 10.0.9's XmlCommentGenerator
          targets the 2.x object model and breaks (CS0200) against Microsoft.OpenApi 3.x. -->

--- a/src/Services/Scheduling/Api/Api.csproj
+++ b/src/Services/Scheduling/Api/Api.csproj
@@ -26,10 +26,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <!-- Direct reference to lift the transitive Microsoft.OpenApi above GHSA-v5pm-xwqc-g5wc.
-         Stay on the 2.x line: Microsoft.AspNetCore.OpenApi 10.0.9's XmlCommentGenerator
-         targets the 2.x object model and breaks (CS0200) against Microsoft.OpenApi 3.x. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 </Project>

--- a/src/Services/Scheduling/Api/ConfigureServices.cs
+++ b/src/Services/Scheduling/Api/ConfigureServices.cs
@@ -22,27 +22,52 @@ public static class ConfigureServices
         services.AddControllers();
         // Query handlers (could consider MediatR later)
         services.AddScoped<KDVManager.Services.Scheduling.Application.Features.PrintSchedules.Queries.GetPrintSchedules.GetPrintSchedulesQueryHandler>();
-        services.AddSwaggerGen(options =>
+        services.AddOpenApi(options =>
         {
-            options.SwaggerDoc("v1", new OpenApiInfo
+            options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
+
+            options.AddDocumentTransformer((document, context, cancellationToken) =>
             {
-                Version = "v1",
-                Title = "KDVManager Scheduling API",
-                Contact = new OpenApiContact
+                document.Info = new()
                 {
-                    Name = "Luuk van Hulten",
-                    Email = "admin@kdvmanager.nl",
-                },
+                    Version = "v1",
+                    Title = "KDVManager Scheduling API",
+                    Contact = new()
+                    {
+                        Name = "Luuk van Hulten",
+                        Email = "admin@kdvmanager.nl",
+                    },
+                };
+
+                return Task.CompletedTask;
             });
 
-            options.DescribeAllParametersInCamelCase();
-
-            // Add a custom schema filter to handle TimeSpan as string with time format
-            options.MapType<TimeSpan>(() => new OpenApiSchema
+            options.AddSchemaTransformer((schema, context, cancellationToken) =>
             {
-                Type = JsonSchemaType.String,
-                Format = "time",
-                Example = JsonValue.Create("14:30:00")
+                if (context.JsonTypeInfo.Type == typeof(TimeSpan))
+                {
+                    schema.Type = JsonSchemaType.String;
+                    schema.Format = "time";
+                    schema.Example = JsonValue.Create("14:30:00");
+                }
+
+                return Task.CompletedTask;
+            });
+
+            options.AddOperationTransformer((operation, context, cancellationToken) =>
+            {
+                if (operation.Parameters != null)
+                {
+                    foreach (var parameter in operation.Parameters)
+                    {
+                        if (parameter is OpenApiParameter openApiParameter && !string.IsNullOrEmpty(openApiParameter.Name))
+                        {
+                            openApiParameter.Name = Char.ToLowerInvariant(openApiParameter.Name[0]) + openApiParameter.Name[1..];
+                        }
+                    }
+                }
+
+                return Task.CompletedTask;
             });
         });
 

--- a/src/Services/Scheduling/Api/ConfigureServices.cs
+++ b/src/Services/Scheduling/Api/ConfigureServices.cs
@@ -51,6 +51,14 @@ public static class ConfigureServices
                     schema.Example = JsonValue.Create("14:30:00");
                 }
 
+                // ASP.NET Core OpenAPI emits a pattern for integer fields without a type,
+                // which causes Orval to generate `unknown` instead of `number`.
+                if (schema.Format == "int32" || schema.Format == "int64")
+                {
+                    schema.Pattern = null;
+                    schema.Type = JsonSchemaType.Integer;
+                }
+
                 return Task.CompletedTask;
             });
 
@@ -65,6 +73,13 @@ public static class ConfigureServices
                             openApiParameter.Name = Char.ToLowerInvariant(openApiParameter.Name[0]) + openApiParameter.Name[1..];
                         }
                     }
+                }
+
+                // A 204 response has no body. Remove the empty JSON media type emitted by
+                // ASP.NET Core OpenAPI so Orval continues to generate Promise<void>.
+                if (operation.Responses?.TryGetValue("204", out var noContentResponse) == true)
+                {
+                    noContentResponse.Content?.Clear();
                 }
 
                 return Task.CompletedTask;

--- a/src/Services/Scheduling/Api/ConfigureServices.cs
+++ b/src/Services/Scheduling/Api/ConfigureServices.cs
@@ -1,9 +1,8 @@
-using Microsoft.OpenApi;
-using System.Text.Json.Nodes;
 using KDVManager.Services.Scheduling.Api.Telemetry;
 using KDVManager.Services.Scheduling.Infrastructure;
 using KDVManager.Shared.Infrastructure.Auth;
 using KDVManager.Shared.Infrastructure.Http;
+using KDVManager.Shared.Infrastructure.OpenApi;
 using KDVManager.Shared.Infrastructure.Telemetry;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -22,69 +21,7 @@ public static class ConfigureServices
         services.AddControllers();
         // Query handlers (could consider MediatR later)
         services.AddScoped<KDVManager.Services.Scheduling.Application.Features.PrintSchedules.Queries.GetPrintSchedules.GetPrintSchedulesQueryHandler>();
-        services.AddOpenApi(options =>
-        {
-            options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
-
-            options.AddDocumentTransformer((document, context, cancellationToken) =>
-            {
-                document.Info = new()
-                {
-                    Version = "v1",
-                    Title = "KDVManager Scheduling API",
-                    Contact = new()
-                    {
-                        Name = "Luuk van Hulten",
-                        Email = "admin@kdvmanager.nl",
-                    },
-                };
-
-                return Task.CompletedTask;
-            });
-
-            options.AddSchemaTransformer((schema, context, cancellationToken) =>
-            {
-                if (context.JsonTypeInfo.Type == typeof(TimeSpan))
-                {
-                    schema.Type = JsonSchemaType.String;
-                    schema.Format = "time";
-                    schema.Example = JsonValue.Create("14:30:00");
-                }
-
-                // ASP.NET Core OpenAPI emits a pattern for integer fields without a type,
-                // which causes Orval to generate `unknown` instead of `number`.
-                if (schema.Format == "int32" || schema.Format == "int64")
-                {
-                    schema.Pattern = null;
-                    schema.Type = JsonSchemaType.Integer;
-                }
-
-                return Task.CompletedTask;
-            });
-
-            options.AddOperationTransformer((operation, context, cancellationToken) =>
-            {
-                if (operation.Parameters != null)
-                {
-                    foreach (var parameter in operation.Parameters)
-                    {
-                        if (parameter is OpenApiParameter openApiParameter && !string.IsNullOrEmpty(openApiParameter.Name))
-                        {
-                            openApiParameter.Name = Char.ToLowerInvariant(openApiParameter.Name[0]) + openApiParameter.Name[1..];
-                        }
-                    }
-                }
-
-                // A 204 response has no body. Remove the empty JSON media type emitted by
-                // ASP.NET Core OpenAPI so Orval continues to generate Promise<void>.
-                if (operation.Responses?.TryGetValue("204", out var noContentResponse) == true)
-                {
-                    noContentResponse.Content?.Clear();
-                }
-
-                return Task.CompletedTask;
-            });
-        });
+        services.AddKdvManagerOpenApi("KDVManager Scheduling API");
 
         services.AddKdvManagerAuthentication(configuration);
 

--- a/src/Services/Scheduling/Api/Program.cs
+++ b/src/Services/Scheduling/Api/Program.cs
@@ -19,7 +19,7 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
+    app.MapOpenApi().AllowAnonymous();
 }
 
 app.UseRouting();

--- a/src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj
+++ b/src/Shared/KDVManager.Shared.Infrastructure/KDVManager.Shared.Infrastructure.csproj
@@ -19,7 +19,12 @@
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.5.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <!-- Direct reference to lift the transitive Microsoft.OpenApi above GHSA-v5pm-xwqc-g5wc.
+         Stay on the 2.x line: Microsoft.AspNetCore.OpenApi 10.0.9's XmlCommentGenerator
+         targets the 2.x object model and breaks (CS0200) against Microsoft.OpenApi 3.x. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.3" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />

--- a/src/Shared/KDVManager.Shared.Infrastructure/OpenApi/KdvManagerOpenApiExtensions.cs
+++ b/src/Shared/KDVManager.Shared.Infrastructure/OpenApi/KdvManagerOpenApiExtensions.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi;
+
+namespace KDVManager.Shared.Infrastructure.OpenApi;
+
+public static class KdvManagerOpenApiExtensions
+{
+    public static IServiceCollection AddKdvManagerOpenApi(this IServiceCollection services, string title)
+    {
+        services.AddOpenApi(options =>
+        {
+            options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
+
+            options.AddDocumentTransformer((document, context, cancellationToken) =>
+            {
+                document.Info = new()
+                {
+                    Title = title,
+                    Version = "v1",
+                    Contact = new()
+                    {
+                        Name = "Luuk van Hulten",
+                        Email = "admin@kdvmanager.nl",
+                    },
+                };
+
+                return Task.CompletedTask;
+            });
+
+            options.AddSchemaTransformer((schema, context, cancellationToken) =>
+            {
+                if (schema.Properties != null)
+                {
+                    schema.Properties = schema.Properties.ToDictionary(
+                        property => char.ToLowerInvariant(property.Key[0]) + property.Key[1..],
+                        property => property.Value);
+                }
+
+                if (context.JsonTypeInfo.Type == typeof(TimeSpan))
+                {
+                    schema.Type = JsonSchemaType.String;
+                    schema.Format = "time";
+                    schema.Example = JsonValue.Create("14:30:00");
+                }
+
+                // ASP.NET Core OpenAPI emits a pattern for integer fields without a type,
+                // which causes Orval to generate `unknown` instead of `number`.
+                if (schema.Format == "int32" || schema.Format == "int64")
+                {
+                    schema.Pattern = null;
+                    schema.Type = JsonSchemaType.Integer;
+                }
+
+                return Task.CompletedTask;
+            });
+
+            options.AddOperationTransformer((operation, context, cancellationToken) =>
+            {
+                if (operation.Parameters != null)
+                {
+                    foreach (var parameter in operation.Parameters)
+                    {
+                        if (parameter is OpenApiParameter openApiParameter && !string.IsNullOrEmpty(openApiParameter.Name))
+                        {
+                            openApiParameter.Name = char.ToLowerInvariant(openApiParameter.Name[0]) + openApiParameter.Name[1..];
+                        }
+                    }
+                }
+
+                // A 204 response has no body. Remove the empty JSON media type emitted by
+                // ASP.NET Core OpenAPI so Orval continues to generate Promise<void>.
+                if (operation.Responses?.TryGetValue("204", out var noContentResponse) == true)
+                {
+                    noContentResponse.Content?.Clear();
+                }
+
+                return Task.CompletedTask;
+            });
+        });
+
+        return services;
+    }
+}

--- a/src/web/orval.config.ts
+++ b/src/web/orval.config.ts
@@ -67,7 +67,7 @@ const config: ReturnType<typeof defineConfig> = {
       },
     },
     input: {
-      target: "http://localhost:5200/scheduling/swagger/v1/swagger.json",
+      target: "http://localhost:5200/scheduling/openapi/v1.json",
     },
   },
 };

--- a/src/web/src/api/scheduling/endpoints/absences/absences.ts
+++ b/src/web/src/api/scheduling/endpoints/absences/absences.ts
@@ -183,7 +183,7 @@ export const getAddAbsenceUrl = (childId: string) => {
 
 export const addAbsence = async (
   childId: string,
-  addAbsenceCommand?: AddAbsenceCommand,
+  addAbsenceCommand: AddAbsenceCommand,
   options?: RequestInit,
 ): Promise<string> => {
   return executeFetch<string>(getAddAbsenceUrl(childId), {
@@ -201,14 +201,14 @@ export const getAddAbsenceMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addAbsence>>,
     TError,
-    { childId: string; data?: AddAbsenceCommand },
+    { childId: string; data: AddAbsenceCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addAbsence>>,
   TError,
-  { childId: string; data?: AddAbsenceCommand },
+  { childId: string; data: AddAbsenceCommand },
   TContext
 > => {
   const mutationKey = ["addAbsence"];
@@ -220,7 +220,7 @@ export const getAddAbsenceMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addAbsence>>,
-    { childId: string; data?: AddAbsenceCommand }
+    { childId: string; data: AddAbsenceCommand }
   > = (props) => {
     const { childId, data } = props ?? {};
 
@@ -231,7 +231,7 @@ export const getAddAbsenceMutationOptions = <
 };
 
 export type AddAbsenceMutationResult = NonNullable<Awaited<ReturnType<typeof addAbsence>>>;
-export type AddAbsenceMutationBody = AddAbsenceCommand | undefined;
+export type AddAbsenceMutationBody = AddAbsenceCommand;
 export type AddAbsenceMutationError = UnprocessableEntityResponse;
 
 export const useAddAbsence = <TError = UnprocessableEntityResponse, TContext = unknown>(
@@ -239,7 +239,7 @@ export const useAddAbsence = <TError = UnprocessableEntityResponse, TContext = u
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addAbsence>>,
       TError,
-      { childId: string; data?: AddAbsenceCommand },
+      { childId: string; data: AddAbsenceCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -248,7 +248,7 @@ export const useAddAbsence = <TError = UnprocessableEntityResponse, TContext = u
 ): UseMutationResult<
   Awaited<ReturnType<typeof addAbsence>>,
   TError,
-  { childId: string; data?: AddAbsenceCommand },
+  { childId: string; data: AddAbsenceCommand },
   TContext
 > => {
   return useMutation(getAddAbsenceMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/endpoints/closure-periods/closure-periods.ts
+++ b/src/web/src/api/scheduling/endpoints/closure-periods/closure-periods.ts
@@ -157,7 +157,7 @@ export const getAddClosurePeriodUrl = () => {
 };
 
 export const addClosurePeriod = async (
-  addClosurePeriodCommand?: AddClosurePeriodCommand,
+  addClosurePeriodCommand: AddClosurePeriodCommand,
   options?: RequestInit,
 ): Promise<string> => {
   return executeFetch<string>(getAddClosurePeriodUrl(), {
@@ -172,14 +172,14 @@ export const getAddClosurePeriodMutationOptions = <TError = unknown, TContext = 
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addClosurePeriod>>,
     TError,
-    { data?: AddClosurePeriodCommand },
+    { data: AddClosurePeriodCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addClosurePeriod>>,
   TError,
-  { data?: AddClosurePeriodCommand },
+  { data: AddClosurePeriodCommand },
   TContext
 > => {
   const mutationKey = ["addClosurePeriod"];
@@ -191,7 +191,7 @@ export const getAddClosurePeriodMutationOptions = <TError = unknown, TContext = 
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addClosurePeriod>>,
-    { data?: AddClosurePeriodCommand }
+    { data: AddClosurePeriodCommand }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -204,7 +204,7 @@ export const getAddClosurePeriodMutationOptions = <TError = unknown, TContext = 
 export type AddClosurePeriodMutationResult = NonNullable<
   Awaited<ReturnType<typeof addClosurePeriod>>
 >;
-export type AddClosurePeriodMutationBody = AddClosurePeriodCommand | undefined;
+export type AddClosurePeriodMutationBody = AddClosurePeriodCommand;
 export type AddClosurePeriodMutationError = unknown;
 
 export const useAddClosurePeriod = <TError = unknown, TContext = unknown>(
@@ -212,7 +212,7 @@ export const useAddClosurePeriod = <TError = unknown, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addClosurePeriod>>,
       TError,
-      { data?: AddClosurePeriodCommand },
+      { data: AddClosurePeriodCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -221,7 +221,7 @@ export const useAddClosurePeriod = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof addClosurePeriod>>,
   TError,
-  { data?: AddClosurePeriodCommand },
+  { data: AddClosurePeriodCommand },
   TContext
 > => {
   return useMutation(getAddClosurePeriodMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/endpoints/end-mark-settings/end-mark-settings.ts
+++ b/src/web/src/api/scheduling/endpoints/end-mark-settings/end-mark-settings.ts
@@ -157,7 +157,7 @@ export const getUpdateEndMarkSettingsUrl = () => {
 };
 
 export const updateEndMarkSettings = async (
-  updateEndMarkSettingsCommand?: UpdateEndMarkSettingsCommand,
+  updateEndMarkSettingsCommand: UpdateEndMarkSettingsCommand,
   options?: RequestInit,
 ): Promise<void> => {
   return executeFetch<void>(getUpdateEndMarkSettingsUrl(), {
@@ -175,14 +175,14 @@ export const getUpdateEndMarkSettingsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updateEndMarkSettings>>,
     TError,
-    { data?: UpdateEndMarkSettingsCommand },
+    { data: UpdateEndMarkSettingsCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updateEndMarkSettings>>,
   TError,
-  { data?: UpdateEndMarkSettingsCommand },
+  { data: UpdateEndMarkSettingsCommand },
   TContext
 > => {
   const mutationKey = ["updateEndMarkSettings"];
@@ -194,7 +194,7 @@ export const getUpdateEndMarkSettingsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updateEndMarkSettings>>,
-    { data?: UpdateEndMarkSettingsCommand }
+    { data: UpdateEndMarkSettingsCommand }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -207,7 +207,7 @@ export const getUpdateEndMarkSettingsMutationOptions = <
 export type UpdateEndMarkSettingsMutationResult = NonNullable<
   Awaited<ReturnType<typeof updateEndMarkSettings>>
 >;
-export type UpdateEndMarkSettingsMutationBody = UpdateEndMarkSettingsCommand | undefined;
+export type UpdateEndMarkSettingsMutationBody = UpdateEndMarkSettingsCommand;
 export type UpdateEndMarkSettingsMutationError = unknown;
 
 export const useUpdateEndMarkSettings = <TError = unknown, TContext = unknown>(
@@ -215,7 +215,7 @@ export const useUpdateEndMarkSettings = <TError = unknown, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updateEndMarkSettings>>,
       TError,
-      { data?: UpdateEndMarkSettingsCommand },
+      { data: UpdateEndMarkSettingsCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -224,7 +224,7 @@ export const useUpdateEndMarkSettings = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof updateEndMarkSettings>>,
   TError,
-  { data?: UpdateEndMarkSettingsCommand },
+  { data: UpdateEndMarkSettingsCommand },
   TContext
 > => {
   return useMutation(getUpdateEndMarkSettingsMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/endpoints/end-marks/end-marks.ts
+++ b/src/web/src/api/scheduling/endpoints/end-marks/end-marks.ts
@@ -165,7 +165,7 @@ export const getAddEndMarkUrl = () => {
 };
 
 export const addEndMark = async (
-  addEndMarkCommand?: AddEndMarkCommand,
+  addEndMarkCommand: AddEndMarkCommand,
   options?: RequestInit,
 ): Promise<void> => {
   return executeFetch<void>(getAddEndMarkUrl(), {
@@ -180,14 +180,14 @@ export const getAddEndMarkMutationOptions = <TError = unknown, TContext = unknow
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addEndMark>>,
     TError,
-    { data?: AddEndMarkCommand },
+    { data: AddEndMarkCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addEndMark>>,
   TError,
-  { data?: AddEndMarkCommand },
+  { data: AddEndMarkCommand },
   TContext
 > => {
   const mutationKey = ["addEndMark"];
@@ -199,7 +199,7 @@ export const getAddEndMarkMutationOptions = <TError = unknown, TContext = unknow
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addEndMark>>,
-    { data?: AddEndMarkCommand }
+    { data: AddEndMarkCommand }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -210,7 +210,7 @@ export const getAddEndMarkMutationOptions = <TError = unknown, TContext = unknow
 };
 
 export type AddEndMarkMutationResult = NonNullable<Awaited<ReturnType<typeof addEndMark>>>;
-export type AddEndMarkMutationBody = AddEndMarkCommand | undefined;
+export type AddEndMarkMutationBody = AddEndMarkCommand;
 export type AddEndMarkMutationError = unknown;
 
 export const useAddEndMark = <TError = unknown, TContext = unknown>(
@@ -218,7 +218,7 @@ export const useAddEndMark = <TError = unknown, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addEndMark>>,
       TError,
-      { data?: AddEndMarkCommand },
+      { data: AddEndMarkCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -227,7 +227,7 @@ export const useAddEndMark = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof addEndMark>>,
   TError,
-  { data?: AddEndMarkCommand },
+  { data: AddEndMarkCommand },
   TContext
 > => {
   return useMutation(getAddEndMarkMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/endpoints/groups/groups.ts
+++ b/src/web/src/api/scheduling/endpoints/groups/groups.ts
@@ -170,7 +170,7 @@ export const getAddGroupUrl = () => {
 };
 
 export const addGroup = async (
-  addGroupCommand?: AddGroupCommand,
+  addGroupCommand: AddGroupCommand,
   options?: RequestInit,
 ): Promise<string> => {
   return executeFetch<string>(getAddGroupUrl(), {
@@ -188,14 +188,14 @@ export const getAddGroupMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addGroup>>,
     TError,
-    { data?: AddGroupCommand },
+    { data: AddGroupCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addGroup>>,
   TError,
-  { data?: AddGroupCommand },
+  { data: AddGroupCommand },
   TContext
 > => {
   const mutationKey = ["addGroup"];
@@ -207,7 +207,7 @@ export const getAddGroupMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addGroup>>,
-    { data?: AddGroupCommand }
+    { data: AddGroupCommand }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -218,7 +218,7 @@ export const getAddGroupMutationOptions = <
 };
 
 export type AddGroupMutationResult = NonNullable<Awaited<ReturnType<typeof addGroup>>>;
-export type AddGroupMutationBody = AddGroupCommand | undefined;
+export type AddGroupMutationBody = AddGroupCommand;
 export type AddGroupMutationError = UnprocessableEntityResponse;
 
 export const useAddGroup = <TError = UnprocessableEntityResponse, TContext = unknown>(
@@ -226,7 +226,7 @@ export const useAddGroup = <TError = UnprocessableEntityResponse, TContext = unk
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addGroup>>,
       TError,
-      { data?: AddGroupCommand },
+      { data: AddGroupCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -235,7 +235,7 @@ export const useAddGroup = <TError = UnprocessableEntityResponse, TContext = unk
 ): UseMutationResult<
   Awaited<ReturnType<typeof addGroup>>,
   TError,
-  { data?: AddGroupCommand },
+  { data: AddGroupCommand },
   TContext
 > => {
   return useMutation(getAddGroupMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/endpoints/schedules/schedules.ts
+++ b/src/web/src/api/scheduling/endpoints/schedules/schedules.ts
@@ -195,7 +195,7 @@ export const getAddScheduleUrl = () => {
 };
 
 export const addSchedule = async (
-  addScheduleCommand?: AddScheduleCommand,
+  addScheduleCommand: AddScheduleCommand,
   options?: RequestInit,
 ): Promise<string> => {
   return executeFetch<string>(getAddScheduleUrl(), {
@@ -213,14 +213,14 @@ export const getAddScheduleMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addSchedule>>,
     TError,
-    { data?: AddScheduleCommand },
+    { data: AddScheduleCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addSchedule>>,
   TError,
-  { data?: AddScheduleCommand },
+  { data: AddScheduleCommand },
   TContext
 > => {
   const mutationKey = ["addSchedule"];
@@ -232,7 +232,7 @@ export const getAddScheduleMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addSchedule>>,
-    { data?: AddScheduleCommand }
+    { data: AddScheduleCommand }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -243,7 +243,7 @@ export const getAddScheduleMutationOptions = <
 };
 
 export type AddScheduleMutationResult = NonNullable<Awaited<ReturnType<typeof addSchedule>>>;
-export type AddScheduleMutationBody = AddScheduleCommand | undefined;
+export type AddScheduleMutationBody = AddScheduleCommand;
 export type AddScheduleMutationError = UnprocessableEntityResponse;
 
 export const useAddSchedule = <TError = UnprocessableEntityResponse, TContext = unknown>(
@@ -251,7 +251,7 @@ export const useAddSchedule = <TError = UnprocessableEntityResponse, TContext = 
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addSchedule>>,
       TError,
-      { data?: AddScheduleCommand },
+      { data: AddScheduleCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -260,7 +260,7 @@ export const useAddSchedule = <TError = UnprocessableEntityResponse, TContext = 
 ): UseMutationResult<
   Awaited<ReturnType<typeof addSchedule>>,
   TError,
-  { data?: AddScheduleCommand },
+  { data: AddScheduleCommand },
   TContext
 > => {
   return useMutation(getAddScheduleMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/endpoints/time-slots/time-slots.ts
+++ b/src/web/src/api/scheduling/endpoints/time-slots/time-slots.ts
@@ -184,7 +184,7 @@ export const getAddTimeSlotUrl = () => {
 };
 
 export const addTimeSlot = async (
-  addTimeSlotCommand?: AddTimeSlotCommand,
+  addTimeSlotCommand: AddTimeSlotCommand,
   options?: RequestInit,
 ): Promise<string> => {
   return executeFetch<string>(getAddTimeSlotUrl(), {
@@ -202,14 +202,14 @@ export const getAddTimeSlotMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addTimeSlot>>,
     TError,
-    { data?: AddTimeSlotCommand },
+    { data: AddTimeSlotCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addTimeSlot>>,
   TError,
-  { data?: AddTimeSlotCommand },
+  { data: AddTimeSlotCommand },
   TContext
 > => {
   const mutationKey = ["addTimeSlot"];
@@ -221,7 +221,7 @@ export const getAddTimeSlotMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addTimeSlot>>,
-    { data?: AddTimeSlotCommand }
+    { data: AddTimeSlotCommand }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -232,7 +232,7 @@ export const getAddTimeSlotMutationOptions = <
 };
 
 export type AddTimeSlotMutationResult = NonNullable<Awaited<ReturnType<typeof addTimeSlot>>>;
-export type AddTimeSlotMutationBody = AddTimeSlotCommand | undefined;
+export type AddTimeSlotMutationBody = AddTimeSlotCommand;
 export type AddTimeSlotMutationError = UnprocessableEntityResponse;
 
 export const useAddTimeSlot = <TError = UnprocessableEntityResponse, TContext = unknown>(
@@ -240,7 +240,7 @@ export const useAddTimeSlot = <TError = UnprocessableEntityResponse, TContext = 
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addTimeSlot>>,
       TError,
-      { data?: AddTimeSlotCommand },
+      { data: AddTimeSlotCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -249,7 +249,7 @@ export const useAddTimeSlot = <TError = UnprocessableEntityResponse, TContext = 
 ): UseMutationResult<
   Awaited<ReturnType<typeof addTimeSlot>>,
   TError,
-  { data?: AddTimeSlotCommand },
+  { data: AddTimeSlotCommand },
   TContext
 > => {
   return useMutation(getAddTimeSlotMutationOptions(options), queryClient);
@@ -260,7 +260,7 @@ export const getUpdateTimeSlotUrl = (id: string) => {
 
 export const updateTimeSlot = async (
   id: string,
-  updateTimeSlotCommand?: UpdateTimeSlotCommand,
+  updateTimeSlotCommand: UpdateTimeSlotCommand,
   options?: RequestInit,
 ): Promise<void> => {
   return executeFetch<void>(getUpdateTimeSlotUrl(id), {
@@ -278,14 +278,14 @@ export const getUpdateTimeSlotMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updateTimeSlot>>,
     TError,
-    { id: string; data?: UpdateTimeSlotCommand },
+    { id: string; data: UpdateTimeSlotCommand },
     TContext
   >;
   request?: SecondParameter<typeof executeFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updateTimeSlot>>,
   TError,
-  { id: string; data?: UpdateTimeSlotCommand },
+  { id: string; data: UpdateTimeSlotCommand },
   TContext
 > => {
   const mutationKey = ["updateTimeSlot"];
@@ -297,7 +297,7 @@ export const getUpdateTimeSlotMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updateTimeSlot>>,
-    { id: string; data?: UpdateTimeSlotCommand }
+    { id: string; data: UpdateTimeSlotCommand }
   > = (props) => {
     const { id, data } = props ?? {};
 
@@ -308,7 +308,7 @@ export const getUpdateTimeSlotMutationOptions = <
 };
 
 export type UpdateTimeSlotMutationResult = NonNullable<Awaited<ReturnType<typeof updateTimeSlot>>>;
-export type UpdateTimeSlotMutationBody = UpdateTimeSlotCommand | undefined;
+export type UpdateTimeSlotMutationBody = UpdateTimeSlotCommand;
 export type UpdateTimeSlotMutationError = ProblemDetails | UnprocessableEntityResponse;
 
 export const useUpdateTimeSlot = <
@@ -319,7 +319,7 @@ export const useUpdateTimeSlot = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updateTimeSlot>>,
       TError,
-      { id: string; data?: UpdateTimeSlotCommand },
+      { id: string; data: UpdateTimeSlotCommand },
       TContext
     >;
     request?: SecondParameter<typeof executeFetch>;
@@ -328,7 +328,7 @@ export const useUpdateTimeSlot = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof updateTimeSlot>>,
   TError,
-  { id: string; data?: UpdateTimeSlotCommand },
+  { id: string; data: UpdateTimeSlotCommand },
   TContext
 > => {
   return useMutation(getUpdateTimeSlotMutationOptions(options), queryClient);

--- a/src/web/src/api/scheduling/models/absenceListByChildIdVM.ts
+++ b/src/web/src/api/scheduling/models/absenceListByChildIdVM.ts
@@ -9,6 +9,5 @@ export type AbsenceListByChildIdVM = {
   id: string;
   startDate: string;
   endDate: string;
-  /** @nullable */
-  reason: string | null;
+  reason: string;
 };

--- a/src/web/src/api/scheduling/models/addClosurePeriodCommand.ts
+++ b/src/web/src/api/scheduling/models/addClosurePeriodCommand.ts
@@ -8,6 +8,5 @@
 export type AddClosurePeriodCommand = {
   startDate?: string;
   endDate?: string;
-  /** @nullable */
-  reason?: string | null;
+  reason?: string;
 };

--- a/src/web/src/api/scheduling/models/addGroupCommand.ts
+++ b/src/web/src/api/scheduling/models/addGroupCommand.ts
@@ -6,6 +6,5 @@
  */
 
 export type AddGroupCommand = {
-  /** @nullable */
-  name?: string | null;
+  name?: string;
 };

--- a/src/web/src/api/scheduling/models/addScheduleCommand.ts
+++ b/src/web/src/api/scheduling/models/addScheduleCommand.ts
@@ -9,6 +9,5 @@ import type { AddScheduleCommandScheduleRule } from "./addScheduleCommandSchedul
 export type AddScheduleCommand = {
   childId?: string;
   startDate?: string;
-  /** @nullable */
-  scheduleRules?: AddScheduleCommandScheduleRule[] | null;
+  scheduleRules?: AddScheduleCommandScheduleRule[];
 };

--- a/src/web/src/api/scheduling/models/addTimeSlotCommand.ts
+++ b/src/web/src/api/scheduling/models/addTimeSlotCommand.ts
@@ -6,8 +6,7 @@
  */
 
 export type AddTimeSlotCommand = {
-  /** @nullable */
-  name?: string | null;
+  name?: string;
   startTime?: string;
   endTime?: string;
 };

--- a/src/web/src/api/scheduling/models/ageGroupSummary.ts
+++ b/src/web/src/api/scheduling/models/ageGroupSummary.ts
@@ -6,7 +6,6 @@
  */
 
 export type AgeGroupSummary = {
-  /** @nullable */
-  ageRange?: string | null;
+  ageRange?: string;
   childCount?: number;
 };

--- a/src/web/src/api/scheduling/models/bkrCalculationSummary.ts
+++ b/src/web/src/api/scheduling/models/bkrCalculationSummary.ts
@@ -10,5 +10,6 @@ import type { BkrProfessionalsBasis } from "./bkrProfessionalsBasis";
 export type BkrCalculationSummary = {
   hasSolution: boolean;
   basis: BkrProfessionalsBasis;
-  appliedRule?: BkrAppliedRule;
+  /** @nullable */
+  appliedRule?: BkrAppliedRule | null;
 };

--- a/src/web/src/api/scheduling/models/childScheduleDailyVM.ts
+++ b/src/web/src/api/scheduling/models/childScheduleDailyVM.ts
@@ -8,14 +8,12 @@
 export type ChildScheduleDailyVM = {
   scheduleId?: string;
   childId?: string;
-  /** @nullable */
-  timeSlotName?: string | null;
+  timeSlotName?: string;
   startTime?: string;
   endTime?: string;
   /** @nullable */
   dateOfBirth?: string | null;
-  /** @nullable */
-  age?: number | null;
+  age?: number;
   isAbsent?: boolean;
   /** @nullable */
   absenceReason?: string | null;

--- a/src/web/src/api/scheduling/models/childScheduleListVM.ts
+++ b/src/web/src/api/scheduling/models/childScheduleListVM.ts
@@ -12,6 +12,5 @@ export type ChildScheduleListVM = {
   startDate?: string;
   /** @nullable */
   endDate?: string | null;
-  /** @nullable */
-  scheduleRules?: ChildScheduleListVMScheduleRule[] | null;
+  scheduleRules?: ChildScheduleListVMScheduleRule[];
 };

--- a/src/web/src/api/scheduling/models/childScheduleListVMScheduleRule.ts
+++ b/src/web/src/api/scheduling/models/childScheduleListVMScheduleRule.ts
@@ -9,11 +9,9 @@ import type { DayOfWeek } from "./dayOfWeek";
 export type ChildScheduleListVMScheduleRule = {
   day?: DayOfWeek;
   timeSlotId?: string;
-  /** @nullable */
-  timeSlotName?: string | null;
+  timeSlotName?: string;
   startTime?: string;
   endTime?: string;
   groupId?: string;
-  /** @nullable */
-  groupName?: string | null;
+  groupName?: string;
 };

--- a/src/web/src/api/scheduling/models/closurePeriodListVM.ts
+++ b/src/web/src/api/scheduling/models/closurePeriodListVM.ts
@@ -9,6 +9,5 @@ export type ClosurePeriodListVM = {
   id?: string;
   startDate?: string;
   endDate?: string;
-  /** @nullable */
-  reason?: string | null;
+  reason?: string;
 };

--- a/src/web/src/api/scheduling/models/dailyOverviewVM.ts
+++ b/src/web/src/api/scheduling/models/dailyOverviewVM.ts
@@ -11,6 +11,5 @@ export type DailyOverviewVM = {
   isClosed?: boolean;
   /** @nullable */
   closureReason?: string | null;
-  /** @nullable */
-  groups?: GroupDailyOverviewVM[] | null;
+  groups?: GroupDailyOverviewVM[];
 };

--- a/src/web/src/api/scheduling/models/dayOfWeek.ts
+++ b/src/web/src/api/scheduling/models/dayOfWeek.ts
@@ -5,14 +5,4 @@
  * OpenAPI spec version: v1
  */
 
-export type DayOfWeek = (typeof DayOfWeek)[keyof typeof DayOfWeek];
-
-export const DayOfWeek = {
-  NUMBER_0: 0,
-  NUMBER_1: 1,
-  NUMBER_2: 2,
-  NUMBER_3: 3,
-  NUMBER_4: 4,
-  NUMBER_5: 5,
-  NUMBER_6: 6,
-} as const;
+export type DayOfWeek = number;

--- a/src/web/src/api/scheduling/models/endMarkSettingsDto.ts
+++ b/src/web/src/api/scheduling/models/endMarkSettingsDto.ts
@@ -8,6 +8,5 @@
 export type EndMarkSettingsDto = {
   isEnabled?: boolean;
   yearsAfterBirth?: number;
-  /** @nullable */
-  description?: string | null;
+  description?: string;
 };

--- a/src/web/src/api/scheduling/models/groupDailyOverviewVM.ts
+++ b/src/web/src/api/scheduling/models/groupDailyOverviewVM.ts
@@ -8,8 +8,6 @@ import type { ChildScheduleDailyVM } from "./childScheduleDailyVM";
 
 export type GroupDailyOverviewVM = {
   groupId?: string;
-  /** @nullable */
-  groupName?: string | null;
-  /** @nullable */
-  schedules?: ChildScheduleDailyVM[] | null;
+  groupName?: string;
+  schedules?: ChildScheduleDailyVM[];
 };

--- a/src/web/src/api/scheduling/models/groupListVM.ts
+++ b/src/web/src/api/scheduling/models/groupListVM.ts
@@ -7,6 +7,5 @@
 
 export type GroupListVM = {
   id?: string;
-  /** @nullable */
-  name?: string | null;
+  name?: string;
 };

--- a/src/web/src/api/scheduling/models/groupSummaryVM.ts
+++ b/src/web/src/api/scheduling/models/groupSummaryVM.ts
@@ -8,11 +8,9 @@ import type { TimeBlockSummary } from "./timeBlockSummary";
 
 export type GroupSummaryVM = {
   groupId: string;
-  /** @nullable */
-  groupName: string | null;
+  groupName: string;
   date: string;
   timeBlocks: TimeBlockSummary[];
-  /** @nullable */
-  requiredProfessionals?: number | null;
+  requiredProfessionals?: number;
   numberOfChildren?: number;
 };

--- a/src/web/src/api/scheduling/models/printCellVM.ts
+++ b/src/web/src/api/scheduling/models/printCellVM.ts
@@ -6,8 +6,7 @@
  */
 
 export type PrintCellVM = {
-  /** @nullable */
-  status?: string | null;
+  status?: string;
   /** @nullable */
   absenceType?: string | null;
   /** @nullable */

--- a/src/web/src/api/scheduling/models/printChildVM.ts
+++ b/src/web/src/api/scheduling/models/printChildVM.ts
@@ -8,17 +8,13 @@ import type { PrintChildVMSchedule } from "./printChildVMSchedule";
 
 export type PrintChildVM = {
   id?: string;
-  /** @nullable */
-  givenName?: string | null;
-  /** @nullable */
-  familyName?: string | null;
+  givenName?: string;
+  familyName?: string;
   /** @nullable */
   dateOfBirth?: string | null;
-  /** @nullable */
   schedule?: PrintChildVMSchedule;
   index?: number;
+  ageDisplay?: string;
   /** @nullable */
-  ageDisplay?: string | null;
-  /** @nullable */
-  readonly name?: string | null;
+  name?: string | null;
 };

--- a/src/web/src/api/scheduling/models/printChildVMSchedule.ts
+++ b/src/web/src/api/scheduling/models/printChildVMSchedule.ts
@@ -6,7 +6,4 @@
  */
 import type { PrintCellVM } from "./printCellVM";
 
-/**
- * @nullable
- */
-export type PrintChildVMSchedule = Record<string, PrintCellVM> | null;
+export type PrintChildVMSchedule = Record<string, PrintCellVM>;

--- a/src/web/src/api/scheduling/models/printGroupVM.ts
+++ b/src/web/src/api/scheduling/models/printGroupVM.ts
@@ -8,8 +8,6 @@ import type { PrintGroupWeekdayPageVM } from "./printGroupWeekdayPageVM";
 
 export type PrintGroupVM = {
   id?: string;
-  /** @nullable */
-  name?: string | null;
-  /** @nullable */
-  pages?: PrintGroupWeekdayPageVM[] | null;
+  name?: string;
+  pages?: PrintGroupWeekdayPageVM[];
 };

--- a/src/web/src/api/scheduling/models/printGroupWeekdayPageVM.ts
+++ b/src/web/src/api/scheduling/models/printGroupWeekdayPageVM.ts
@@ -9,8 +9,6 @@ import type { PrintChildVM } from "./printChildVM";
 
 export type PrintGroupWeekdayPageVM = {
   weekday?: DayOfWeek;
-  /** @nullable */
-  dates?: string[] | null;
-  /** @nullable */
-  children?: PrintChildVM[] | null;
+  dates?: string[];
+  children?: PrintChildVM[];
 };

--- a/src/web/src/api/scheduling/models/printSchedulesVM.ts
+++ b/src/web/src/api/scheduling/models/printSchedulesVM.ts
@@ -7,9 +7,7 @@
 import type { PrintGroupVM } from "./printGroupVM";
 
 export type PrintSchedulesVM = {
-  /** @nullable */
-  month?: string | null;
+  month?: string;
   year?: number;
-  /** @nullable */
-  groups?: PrintGroupVM[] | null;
+  groups?: PrintGroupVM[];
 };

--- a/src/web/src/api/scheduling/models/problemDetails.ts
+++ b/src/web/src/api/scheduling/models/problemDetails.ts
@@ -10,11 +10,9 @@ export type ProblemDetails = {
   type?: string | null;
   /** @nullable */
   title?: string | null;
-  /** @nullable */
-  status?: number | null;
+  status?: number;
   /** @nullable */
   detail?: string | null;
   /** @nullable */
   instance?: string | null;
-  [key: string]: unknown;
 };

--- a/src/web/src/api/scheduling/models/scheduleByDateVM.ts
+++ b/src/web/src/api/scheduling/models/scheduleByDateVM.ts
@@ -10,13 +10,11 @@ export type ScheduleByDateVM = {
   childId?: string;
   /** @nullable */
   childFullName?: string | null;
-  /** @nullable */
-  timeSlotName?: string | null;
+  timeSlotName?: string;
   startTime?: string;
   endTime?: string;
   groupId?: string;
   /** @nullable */
   dateOfBirth?: string | null;
-  /** @nullable */
-  age?: number | null;
+  age?: number;
 };

--- a/src/web/src/api/scheduling/models/timeBlockSummary.ts
+++ b/src/web/src/api/scheduling/models/timeBlockSummary.ts
@@ -10,12 +10,9 @@ import type { BkrCalculationSummary } from "./bkrCalculationSummary";
 export type TimeBlockSummary = {
   startTime: string;
   endTime: string;
-  /** @nullable */
-  timeSlotName: string | null;
+  timeSlotName: string;
   totalChildren: number;
-  /** @nullable */
-  requiredProfessionals?: number | null;
-  /** @nullable */
-  ageGroups: AgeGroupSummary[] | null;
+  requiredProfessionals?: number;
+  ageGroups: AgeGroupSummary[];
   bkr: BkrCalculationSummary;
 };

--- a/src/web/src/api/scheduling/models/timeSlotListVM.ts
+++ b/src/web/src/api/scheduling/models/timeSlotListVM.ts
@@ -7,8 +7,7 @@
 
 export type TimeSlotListVM = {
   id?: string;
-  /** @nullable */
-  name?: string | null;
+  name?: string;
   startTime?: string;
   endTime?: string;
 };

--- a/src/web/src/api/scheduling/models/updateEndMarkSettingsCommand.ts
+++ b/src/web/src/api/scheduling/models/updateEndMarkSettingsCommand.ts
@@ -8,6 +8,5 @@
 export type UpdateEndMarkSettingsCommand = {
   isEnabled?: boolean;
   yearsAfterBirth?: number;
-  /** @nullable */
-  description?: string | null;
+  description?: string;
 };

--- a/src/web/src/api/scheduling/models/updateTimeSlotCommand.ts
+++ b/src/web/src/api/scheduling/models/updateTimeSlotCommand.ts
@@ -7,8 +7,7 @@
 
 export type UpdateTimeSlotCommand = {
   id?: string;
-  /** @nullable */
-  name?: string | null;
+  name?: string;
   startTime?: string;
   endTime?: string;
 };

--- a/src/web/src/api/scheduling/models/validationError.ts
+++ b/src/web/src/api/scheduling/models/validationError.ts
@@ -6,10 +6,7 @@
  */
 
 export type ValidationError = {
-  /** @minLength 1 */
   property: string;
-  /** @minLength 1 */
   code: string;
-  /** @minLength 1 */
   title: string;
 };


### PR DESCRIPTION
## Summary

- replace Swashbuckle in the Scheduling API with Microsoft.AspNetCore.OpenApi
- expose the development OpenAPI document through MapOpenApi
- preserve document metadata, camel-cased parameters, and the TimeSpan schema contract

## Why

The Scheduling API now uses the same Microsoft-supported OpenAPI stack as the CRM API, removing its remaining Swashbuckle dependency.

## Validation

- dotnet restore src/Services/Scheduling/Api/Api.csproj
- dotnet build src/Services/Scheduling/Api/Api.csproj --no-restore

Build succeeds; the existing ASP0019 warning in shared middleware remains.