### PR TITLE
fix daily schedule avatar contrast

### DIFF
--- a/src/web/src/components/ChildCard.tsx
+++ b/src/web/src/components/ChildCard.tsx
@@ -63,6 +63,8 @@ const ChildCard = ({ childId, schedule }: ChildCardProps) => {
     return categorical[Math.abs(hash) % categorical.length];
   };
 
+  const avatarColor = getAvatarColor();
+
   return (
     <Card
       sx={{
@@ -102,7 +104,8 @@ const ChildCard = ({ childId, schedule }: ChildCardProps) => {
                   sx={{
                     width: { xs: 32, sm: 36 },
                     height: { xs: 32, sm: 36 },
-                    bgcolor: getAvatarColor(),
+                    bgcolor: avatarColor,
+                    color: theme.palette.getContrastText(avatarColor),
                     fontSize: { xs: "0.75rem", sm: "0.85rem" },
                     fontWeight: "bold",
                     flexShrink: 0,


### PR DESCRIPTION
## Summary

- derive each daily-schedule avatar's text color from its hashed background color
- use the theme's WCAG AA 4.5:1 contrast threshold

## Root cause

The child avatar used a categorical background while retaining MUI's default white foreground. Lighter palette entries, particularly orange, did not provide sufficient contrast with white text.

## Impact

Child initials on the planning overview now use an accessible foreground color without changing the stable per-child background colors.

## Validation

- `git diff --check origin/main...HEAD`
- confirmed the branch contains one commit changing one file

TypeScript verification could not run in the sandbox because the web dependencies were unavailable and npm registry access failed.
