### PR TITLE
test daily schedule avatar contrast

### DIFF
--- a/src/web/src/components/ChildCard.test.tsx
+++ b/src/web/src/components/ChildCard.test.tsx
@@ -1,0 +1,52 @@
+import { ThemeProvider, getContrastRatio } from "@mui/material/styles";
+import { page } from "vitest/browser";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ScheduleByDateVM } from "@api/scheduling/models/scheduleByDateVM";
+import { theme } from "@lib/theme";
+import { renderWithProviders } from "../test/renderWithProviders";
+
+vi.mock("@api/crm/endpoints/children/children", () => ({
+  useGetChildById: () => ({
+    data: { givenName: "Jane", familyName: "Doe" },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+const importChildCard = async () => (await import("./ChildCard")).default;
+
+const schedule = {
+  age: 3,
+  startTime: "08:00:00",
+  endTime: "17:00:00",
+  timeSlotName: "Whole day",
+} as ScheduleByDateVM;
+
+describe("ChildCard avatar contrast", () => {
+  // For a one-character ID, the hash is its character code. These IDs therefore
+  // select categorical palette indexes 0 through 7 without depending on random UUIDs.
+  it.each(["@", "A", "B", "C", "D", "E", "F", "G"])(
+    "meets WCAG AA for categorical color selected by child ID %s",
+    async (childId) => {
+      const ChildCard = await importChildCard();
+
+      await renderWithProviders(
+        <ThemeProvider theme={theme}>
+          <ChildCard childId={childId} schedule={schedule} />
+        </ThemeProvider>,
+      );
+
+      await expect.element(page.getByText("JD")).toBeVisible();
+      const avatar = document.querySelector<HTMLElement>(".MuiAvatar-root");
+      expect(avatar).not.toBeNull();
+
+      const styles = getComputedStyle(avatar!);
+      expect(getContrastRatio(styles.color, styles.backgroundColor)).toBeGreaterThanOrEqual(4.5);
+    },
+  );
+});

--- a/tests/e2e/specs/schedule-overview.spec.ts
+++ b/tests/e2e/specs/schedule-overview.spec.ts
@@ -14,6 +14,7 @@
 import { test, expect, type Page, type Locator } from "@playwright/test";
 import { gotoApp } from "../helpers/app";
 import { Api, uniqueName } from "../helpers/api";
+import { expectNoWcagViolations } from "../helpers/a11y";
 
 /** Format a Date as local YYYY-MM-DD (no UTC conversion surprises). */
 function isoDate(date: Date): string {
@@ -133,7 +134,7 @@ test.afterAll(async () => {
 });
 
 test.describe("schedule overview", () => {
-  test("shows the scheduled child inside its group column", async ({ page }) => {
+  test("shows an accessible scheduled child inside its group column", async ({ page }, testInfo) => {
     await gotoApp(page, `/schedule?date=${scheduledDate}`);
 
     const column = groupColumn(page, groupName);
@@ -141,6 +142,7 @@ test.describe("schedule overview", () => {
       timeout: 15_000,
     });
     await expect(column.getByText(childFullName)).toBeVisible({ timeout: 15_000 });
+    await expectNoWcagViolations(page, testInfo, "schedule-overview-populated");
   });
 
   test("date navigation updates the date URL param", async ({ page }) => {


### PR DESCRIPTION
## Summary

- run axe against the populated daily schedule overview after its child card renders
- verify the computed avatar foreground/background contrast for every categorical palette color

## Why

The route-level accessibility scan intentionally exercises an empty schedule, so it did not render a child avatar. The functional schedule test rendered one child but did not run axe, and its generated ID could select any palette entry.

The deterministic browser test uses IDs that map to all eight categorical colors, preventing a passing result from depending on a randomly generated child ID.

## Validation

- `pnpm --dir src/web test -- src/components/ChildCard.test.tsx` (36 tests passed, including 8 avatar contrast cases)
- `pnpm --dir src/web typecheck`
- `pnpm --dir tests/e2e exec tsc --noEmit`
- `pnpm --dir src/web exec eslint src/components/ChildCard.test.tsx`
- `git diff --check`

The full seeded E2E scenario requires the application stack and was not run locally.
