### PR TITLE
fix: reset child details scroll position

### DIFF
--- a/src/web/src/components/ScrollToTop.test.tsx
+++ b/src/web/src/components/ScrollToTop.test.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { expect, it } from "vitest";
+import { page, userEvent } from "vitest/browser";
+
+import { renderWithProviders } from "../test/renderWithProviders";
+import { ScrollToTop } from "./ScrollToTop";
+
+const Harness = () => {
+  const [childId, setChildId] = useState("child-1");
+
+  const openAnotherChild = () => {
+    window.scrollTo({ top: 500, left: 0, behavior: "auto" });
+    setChildId("child-2");
+  };
+
+  return (
+    <div style={{ minHeight: 2000 }}>
+      <ScrollToTop resetKey={childId} />
+      <button type="button" onClick={openAnotherChild}>
+        Open child
+      </button>
+    </div>
+  );
+};
+
+it("resets the document scroll position when a different child opens", async () => {
+  await page.viewport(375, 667);
+  await renderWithProviders(<Harness />);
+
+  await userEvent.click(page.getByRole("button", { name: "Open child" }));
+
+  await expect.poll(() => window.scrollY).toBe(0);
+});

--- a/src/web/src/components/ScrollToTop.tsx
+++ b/src/web/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useLayoutEffect } from "react";
+
+type ScrollToTopProps = {
+  resetKey: string;
+};
+
+/** Resets the document scroll position when the displayed entity changes. */
+export const ScrollToTop = ({ resetKey }: ScrollToTopProps) => {
+  useLayoutEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [resetKey]);
+
+  return null;
+};

--- a/src/web/src/pages/children/UpdateChildPageModernTabs.tsx
+++ b/src/web/src/pages/children/UpdateChildPageModernTabs.tsx
@@ -8,6 +8,7 @@ import { type updateChildPageLoader } from "./updateChildPage.loader";
 import { ChildHeader } from "../../components/child/ChildHeader";
 import { GeneralInformationTab } from "./tabs/GeneralInformationTab";
 import { PlanningTab } from "./tabs/PlanningTab";
+import { ScrollToTop } from "@components/ScrollToTop";
 
 type TabPanelProps = {
   children?: React.ReactNode;
@@ -81,6 +82,8 @@ const UpdateChildPageModernTabs = () => {
         pb: { xs: 8, md: 6 }, // More bottom padding on mobile for better scrolling
       }}
     >
+      <ScrollToTop resetKey={childId} />
+
       {/* Header */}
       <Box sx={{ mb: { xs: 1, md: 2 }, mx: { xs: -2, md: 0 } }}>
         {/* Stretch header edge-to-edge on mobile by negative margin compensating for Container padding in layout */}


### PR DESCRIPTION
## Summary
- reset the document scroll position when a child detail page opens
- keep the current position when switching tabs for the same child
- add a mobile Chromium regression test

## Why
Client-side navigation retained the planning overview's document scroll offset. Opening a child card lower on the mobile page therefore rendered the child details at that same offset instead of at the top.

## Impact
Child details now open at the top consistently on mobile and desktop, without changing same-child tab navigation.

## Validation
- Prettier check
- ESLint on changed files
- TypeScript test-project typecheck
- Vitest browser regression test in Chromium
