### PR TITLE
chore: upgrade SigNoz to 0.132.2

### DIFF
--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - infrastructure/
 - applications/
 - observability/
+- observability/signoz-application.yaml
 - node-utilities/
 
 # Common labels applied to all resources

--- a/deploy/k8s/observability/kustomization.yaml
+++ b/deploy/k8s/observability/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - otel-collector-deployment.yaml
   - otel-collector-service.yaml
   - otel-collector-rbac.yaml
-  - signoz-application.yaml
 
 labels:
 - pairs:

--- a/deploy/k8s/observability/signoz-application.yaml
+++ b/deploy/k8s/observability/signoz-application.yaml
@@ -12,16 +12,15 @@ spec:
   project: default
   source:
     repoURL: https://charts.signoz.io
-    targetRevision: 0.88.2
+    targetRevision: 0.132.2
     chart: signoz
     helm:
       values: |
         global:
           storageClass: do-block-storage
 
-        # In chart 0.88.2 clickhouse and otelCollector are top-level keys, and
-        # queryService/frontend/alertmanager are merged into the unified
-        # `signoz` component.
+        # clickhouse and otelCollector are top-level chart values. The UI,
+        # API, ruler, and Alertmanager run in the unified `signoz` component.
         clickhouse:
           resources:
             requests:

--- a/docs/observability-setup.md
+++ b/docs/observability-setup.md
@@ -1,6 +1,6 @@
 # Observability Stack
 
-_Last updated: 2026-07-06. For the review that shaped this setup, see [observability-review.md](observability-review.md)._
+_Last updated: 2026-07-14. For the review that shaped this setup, see [observability-review.md](observability-review.md)._
 
 ## Architecture
 
@@ -17,8 +17,10 @@ k8s_cluster + kubeletstats ────────────────┘  
                                               SigNoz UI: https://signoz.kdvmanager.nl
 ```
 
-- **SigNoz** (traces, metrics, logs, dashboards, alerts) — official Helm chart, pinned in
-  `deploy/k8s/observability/signoz-application.yaml`, deployed by ArgoCD into the `signoz` namespace.
+- **SigNoz** (traces, metrics, logs, dashboards, alerts) — official Helm chart `0.132.2`
+  (SigNoz `v0.132.2`), pinned in `deploy/k8s/observability/signoz-application.yaml` and deployed by
+  ArgoCD into the `signoz` namespace. The chart also owns ClickHouse `25.12.5` and the
+  `signoz-telemetrystore-migrator` job that applies schema and background data migrations.
 - **OpenTelemetry Collector** (gateway) — pinned `opentelemetry-collector-contrib` image, deployed from
   `deploy/k8s/observability/` into the `observability` namespace. Receives OTLP from all services,
   Envoy, and the browser; scrapes Envoy's Prometheus stats; collects cluster/kubelet metrics; exports
@@ -92,12 +94,13 @@ points the web build at `http://localhost:5200/telemetry`. Services pick up the 
 | Pod not Ready | `kubectl describe pod` → readiness probe on `/readyz` — failing check names Postgres or the bus |
 | No telemetry arriving | `kubectl logs deploy/otel-collector -n observability`; health `:13133`, pipeline introspection via zpages `:55679`; then SigNoz collector in `signoz` ns |
 | SigNoz down/slow | `kubectl get pods -n signoz`; ClickHouse memory caps are set in the Application values |
+| SigNoz upgrade stuck | `kubectl get job signoz-telemetrystore-migrator -n signoz`; inspect it with `kubectl logs job/signoz-telemetrystore-migrator -n signoz --all-containers` |
 | ArgoCD drift | `kubectl get application signoz -n argocd` (chart) and the kustomize app for `deploy/k8s/observability` |
 
 ## Known gaps / follow-ups
 
-1. **Alerting**: SigNoz alert rules + a notification channel are not yet configured (do this in the
-   SigNoz UI), and there is no external uptime check for kdvmanager.nl itself.
+1. **Alerting**: revalidate the existing rules and email notification channel after the SigNoz
+   upgrade; there is still no external uptime check for kdvmanager.nl itself.
 2. **Retention**: set explicitly in SigNoz (Settings → General); ClickHouse disk is small (5Gi).
 3. **Business metrics**: the per-service meters currently only count errors — domain metrics
    (schedules created, registrations, absences) belong there.


### PR DESCRIPTION
## Summary

- upgrade the SigNoz Helm chart from 0.88.2 (SigNoz v0.91.0) to 0.132.2 (SigNoz v0.132.2)
- move the SigNoz ArgoCD Application out of the namespaced observability Kustomize layer so it updates the controller-watched `argocd/signoz` resource instead of the inert `observability/signoz` duplicate
- document ClickHouse 25.12.5 and the chart-managed `signoz-telemetrystore-migrator` runbook

## Why

The current SigNoz v0.91.0 deployment does not expose the `/api/v2/rules` API used by the SigNoz MCP alert tools. The repository also rendered the Application CR into the `observability` namespace, while the healthy live Application is in `argocd`, so prior GitOps changes did not control the active deployment.

## Deployment impact

This is a large upgrade and changes ClickHouse from 24.1.2 to 25.12.5. The chart renders the new telemetrystore migration job and preserves the existing 5Gi persistence and small-cluster resource overrides.

SigNoz's upgrade-path metadata identifies v0.92.0, v0.94.0, v0.113.0, and v0.131.0 as mandatory checkpoints between the deployed and target versions. This PR intentionally pins the requested latest target; monitor the migration job and workload health closely during ArgoCD sync.

## Validation

- `helm lint /private/tmp/signoz-0.132.2.tgz --namespace signoz -f /private/tmp/kdv-signoz-values-0.132.2.yaml`
- `kubectl kustomize deploy/k8s`
- `kubectl apply --dry-run=server -f /private/tmp/kdvmanager-signoz-kustomize.yaml`
- `kubectl apply -n signoz --dry-run=server -f /private/tmp/signoz-rendered-0.132.2.yaml`
- `git diff --check`
