### PR TITLE
fix: unblock SigNoz telemetry-store migrations

### DIFF
--- a/deploy/k8s/observability/signoz-application.yaml
+++ b/deploy/k8s/observability/signoz-application.yaml
@@ -28,7 +28,7 @@ spec:
               memory: 640Mi
             limits:
               cpu: 800m
-              memory: 1280Mi
+              memory: 2Gi
           persistence:
             size: 5Gi
           # Per-query memory caps (ClickHouse user profile settings)
@@ -36,10 +36,11 @@ spec:
             default/max_memory_usage: "300000000"
             default/max_bytes_before_external_group_by: "200000000"
             default/max_bytes_before_external_sort: "200000000"
-          # Server-wide memory caps; max_server_memory_usage replaces the
-          # long-removed max_memory_usage_for_all_queries setting
+          # Keep caches bounded, but let ClickHouse derive its server-wide
+          # memory budget from the container limit. A fixed 600 MB cap is
+          # below ClickHouse's baseline usage after the SigNoz upgrade and
+          # prevents telemetry-store migrations from completing.
           settings:
-            max_server_memory_usage: "600000000"
             uncompressed_cache_size: "0"
             mark_cache_size: "268435456"
 


### PR DESCRIPTION
## Summary
- raise the ClickHouse container memory limit from 1280Mi to 2Gi
- remove the obsolete 600 MB server-wide memory cap
- keep the existing per-query limits and bounded caches

## Context
After the SigNoz upgrade, the telemetry-store migrator failed at trace migration 1006 and the collector remained blocked waiting for migration 1009. ClickHouse was at its cgroup memory limit and repeatedly returned MEMORY_LIMIT_EXCEEDED against the fixed 600 MB server cap.

## Verification
- git diff --check
- live cluster diagnosis confirmed the missing migrations and ClickHouse memory pressure