### PR TITLE
fix: configure SigNoz SMTP alert delivery

### DIFF
--- a/deploy/k8s/observability/signoz-application.yaml
+++ b/deploy/k8s/observability/signoz-application.yaml
@@ -45,6 +45,27 @@ spec:
             mark_cache_size: "268435456"
 
         signoz:
+          # Alert notifications use Ziggo SMTP. Credentials stay in the
+          # manually managed signoz-smtp Secret and are never stored in Git.
+          env:
+            signoz_alertmanager_signoz_external__url: https://signoz.kdvmanager.nl
+            SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__SMARTHOST: smtp.ziggo.nl:587
+            SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__FROM:
+              valueFrom:
+                secretKeyRef:
+                  name: signoz-smtp
+                  key: username
+            SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__AUTH__USERNAME:
+              valueFrom:
+                secretKeyRef:
+                  name: signoz-smtp
+                  key: username
+            SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__AUTH__PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: signoz-smtp
+                  key: password
+            SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__REQUIRE__TLS: "true"
           ingress:
             enabled: true
             className: nginx


### PR DESCRIPTION
## Summary

- configure SigNoz Alertmanager to use `smtp.ziggo.nl:587` with required TLS
- load the SMTP username/from-address and password from the existing `signoz/signoz-smtp` Kubernetes Secret
- set the external Alertmanager URL to `https://signoz.kdvmanager.nl` so notification links are correct

## Why

The existing Email notification channel pointed at `localhost:25`, where no SMTP listener exists. As a result, corrected and compliance-supporting alert rules could not deliver notifications.

## Security

SMTP credentials are referenced through `secretKeyRef` and are not committed to Git.

## Validation

- parsed the Argo CD Application as YAML
- rendered SigNoz Helm chart `0.132.2`
- verified the rendered StatefulSet contains the Ziggo smarthost, TLS requirement, external URL, and Secret references
- `git diff --check`

## Deployment note

The `signoz-smtp` Secret must exist in the `signoz` namespace before Argo CD syncs this change.
